### PR TITLE
Updated the converter

### DIFF
--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -15,7 +15,7 @@ from ROOT import TG4Event, TFile, TMap
 
 # Output array datatypes
 segments_dtype = np.dtype([("event_id","u4"),("vertex_id", "u8"), ("segment_id", "u4"),
-                           ("z_end", "f4"),("traj_id", "u4"), ("tran_diff", "f4"),
+                           ("z_end", "f4"),("traj_id", "u4"), ("file_traj_id", "u4"), ("tran_diff", "f4"),
                            ("z_start", "f4"), ("x_end", "f4"),
                            ("y_end", "f4"), ("n_electrons", "u4"),
                            ("pdg_id", "i4"), ("x_start", "f4"),
@@ -439,6 +439,7 @@ def dump(input_file, output_file, keep_all_dets=False):
                 segment_id += 1
                 try:
                     segment[iHit]["traj_id"] = hitSegment.Contrib[0]
+                    segment[iHit]["file_traj_id"] = trackMap[hitSegment.Contrib[0]]
                     seg_traj_id = hitSegment.Contrib[0]
                     if segment[iHit]["traj_id"] not in trajectories["traj_id"]:
                         # Given event.Trajectories is ordered by traj_id (trajectory.GetTrackId())

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -28,7 +28,7 @@ segments_dtype = np.dtype([("event_id","u4"),("vertex_id", "u8"), ("segment_id",
                            ("n_photons","f4")], align=True)
 
 trajectories_dtype = np.dtype([("event_id","u4"), ("vertex_id", "u8"),
-                               ("traj_id", "u4"), ("file_traj_id", "u4"), ("parent_id", "i4"),
+                               ("traj_id", "u4"), ("file_traj_id", "u4"), ("parent_id", "i4"), ("primary", "?"),
                                ("E_start", "f4"), ("pxyz_start", "f4", (3,)),
                                ("xyz_start", "f4", (3,)), ("t_start", "f8"),
                                ("E_end", "f4"), ("pxyz_end", "f4", (3,)),
@@ -398,8 +398,8 @@ def dump(input_file, output_file, keep_all_dets=False):
 
                 trajectories[n_traj]["traj_id"] = trajectory.GetTrackId()
                 trajectories[n_traj]["file_traj_id"] = trackMap[trajectory.GetTrackId()]
-                trajectories[n_traj]["parent_id"] = -1 if trajectory.GetParentId() == -1 \
-                    else trajectory.GetParentId()
+                trajectories[n_traj]["parent_id"] = trajectory.GetParentId()
+                trajectories[n_traj]["primary"] = True if trajectory.GetParentId() == -1 else False # primary particle parents trajectory id are -1
 
                 mass = trajectory.GetInitialMomentum().M()
                 p_start = (start_pt.GetMomentum().X(), start_pt.GetMomentum().Y(), start_pt.GetMomentum().Z())
@@ -459,8 +459,8 @@ def dump(input_file, output_file, keep_all_dets=False):
 
                             trajectories[n_traj]["traj_id"] = trajectory.GetTrackId()
                             trajectories[n_traj]["file_traj_id"] = trackMap[trajectory.GetTrackId()]
-                            trajectories[n_traj]["parent_id"] = -1 if trajectory.GetParentId() == -1 \
-                                else trajectory.GetParentId()
+                            trajectories[n_traj]["parent_id"] = trajectory.GetParentId()
+                            trajectories[n_traj]["primary"] = True if trajectory.GetParentId() == -1 else False # primary particle parents trajectory id are -1
 
                             mass = trajectory.GetInitialMomentum().M()
                             p_start = (start_pt.GetMomentum().X(), start_pt.GetMomentum().Y(), start_pt.GetMomentum().Z())

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -391,6 +391,39 @@ def dump(input_file, output_file, keep_all_dets=False):
             trackCounter += 1
             trackMap[trajectory.GetTrackId()] = fileTrackID
 
+            if trajectory.GetParentId() == -1:
+                start_pt, end_pt = trajectory.Points[0], trajectory.Points[-1]
+                trajectories[n_traj]["event_id"] = spill_it
+                trajectories[n_traj]["vertex_id"] = globalVertexID
+
+                trajectories[n_traj]["traj_id"] = trajectory.GetTrackId()
+                trajectories[n_traj]["file_traj_id"] = trackMap[trajectory.GetTrackId()]
+                trajectories[n_traj]["parent_id"] = -1 if trajectory.GetParentId() == -1 \
+                    else trajectory.GetParentId()
+
+                mass = trajectory.GetInitialMomentum().M()
+                p_start = (start_pt.GetMomentum().X(), start_pt.GetMomentum().Y(), start_pt.GetMomentum().Z())
+                p_end = (end_pt.GetMomentum().X(), end_pt.GetMomentum().Y(), end_pt.GetMomentum().Z())
+
+                trajectories[n_traj]["pxyz_start"] = p_start #(start_pt.GetMomentum().X(), start_pt.GetMomentum().Y(), start_pt.GetMomentum().Z())
+                trajectories[n_traj]["pxyz_end"] = p_end #(end_pt.GetMomentum().X(), end_pt.GetMomentum().Y(), end_pt.GetMomentum().Z())
+                trajectories[n_traj]["xyz_start"] = (start_pt.GetPosition().X() * edep2cm, start_pt.GetPosition().Y() * edep2cm, start_pt.GetPosition().Z() * edep2cm)
+                trajectories[n_traj]["xyz_end"] = (end_pt.GetPosition().X() * edep2cm, end_pt.GetPosition().Y() * edep2cm, end_pt.GetPosition().Z() * edep2cm)
+                trajectories[n_traj]["E_start"] = np.sqrt(np.sum(np.square(p_start)) + mass**2)
+                trajectories[n_traj]["E_end"] = np.sqrt(np.sum(np.square(p_end)) + mass**2)
+                trajectories[n_traj]["t_start"] = start_pt.GetPosition().T() * edep2us
+                trajectories[n_traj]["t_end"] = end_pt.GetPosition().T() * edep2us
+                trajectories[n_traj]["start_process"] = start_pt.GetProcess()
+                trajectories[n_traj]["start_subprocess"] = start_pt.GetSubprocess()
+                trajectories[n_traj]["end_process"] = end_pt.GetProcess()
+                trajectories[n_traj]["end_subprocess"] = end_pt.GetSubprocess()
+                trajectories[n_traj]["pdg_id"] = trajectory.GetPDGCode()
+
+                n_traj += 1
+
+            else:
+                continue
+
         # Dump the segment containers
         #print("Number of segment containers:", event.SegmentDetectors.size())
         for containerName, hitSegments in event.SegmentDetectors:

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -482,8 +482,7 @@ def dump(input_file, output_file, keep_all_dets=False):
                 segment[iHit]["t0"] = (segment[iHit]["t0_start"] + segment[iHit]["t0_end"]) / 2.
                 segment[iHit]["t"] = 0
                 segment[iHit]["dEdx"] = hitSegment.GetEnergyDeposit() / dx if dx > 0 else 0
-                #segment[iHit]["pdg_id"] = trajectories[trajectories["traj_id"]==hitSegment.Contrib[0]]["pdg_id"]
-                segment[iHit]["pdg_id"] = trajectories[hitSegment.Contrib[0]]["pdg_id"]
+                segment[iHit]["pdg_id"] = trajectories[trajectories["traj_id"]==hitSegment.Contrib[0]]["pdg_id"]
                 segment[iHit]["n_electrons"] = 0
                 segment[iHit]["long_diff"] = 0
                 segment[iHit]["tran_diff"] = 0


### PR DESCRIPTION
1. Reversed "traj_id" to the TrackId from edepsim (See S10 here: https://docs.dunescience.org/cgi-bin/private/RetrieveFile?docid=29612&filename=2x2_analysis_meeting_2x2_simulation_calibration_16nov2023.pdf&version=1)
2. Corrected the "pdg_id" in segments dataset (See Issue 33)
3. Store all primary tracks even if they have no descendants in the 2x2 detector
4. Added a new attribute "primary" to label the primary particles.

For 3. 
<img width="579" alt="Screenshot 2023-12-14 at 2 42 38 PM" src="https://github.com/DUNE/2x2_sim/assets/25907864/5e4682a6-eefb-40ab-903b-597ce45247b4">
