### PR TITLE
Update reaction code to match CAFs

### DIFF
--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -180,6 +180,8 @@ def matchTrackID(traj_list, part_4mom, part_pdg):
 #Map from GENIE reaction to number to match CAFs
 #Derived from the enum defition and genie::ScatteringType::AsString() fuction from here:
 #https://github.com/GENIE-MC/Generator/blob/master/src/Framework/Interaction/ScatteringType.h
+#which is copied to duneanaobj/StandardRecord
+#https://github.com/DUNE/duneanaobj/blob/main/duneanaobj/StandardRecord/SREnums.h
 genie_reaction_map = {
     "QES" : 1,
     "1Kaon" : 2,


### PR DESCRIPTION
Change the reaction code/variable in the MC truth dataset to match what is used for CAFs. This numbering comes from the GENIE enum definition for scattering modes.

For now the isXYZ reaction flags are still saved. May be removed in the future.

GENIE scattering modes/types can be found here:
https://github.com/GENIE-MC/Generator/blob/master/src/Framework/Interaction/ScatteringType.h