### PR TITLE
Updates for Full NDLAr During Fresh Pass (Round 2)

### DIFF
--- a/admin/install_everything.sh
+++ b/admin/install_everything.sh
@@ -3,7 +3,9 @@
 # Run me from the root directory of 2x2_sim
 
 # Currently larnd-sim and ndlar_flow are the only things we're installing
-# locally. Everything else comes either from a container or CVMFS.
+# locally. Everything else comes either from a container or CVMFS. If using
+# the ARCUBE_USE_GHEP_POT option, need to install a single executable via
+# install_hadd.sh.
 
 set -o errexit
 
@@ -17,6 +19,10 @@ set -o errexit
 
 # export ARCUBE_DIR=$PWD
 # export ARCUBE_CONTAINER_DIR=$ARCUBE_DIR/admin/containers
+
+pushd run-hadd
+./install_hadd.sh
+popd
 
 # pushd run-spill-build
 # ./install_spill_build.sh

--- a/run-hadd/README.md
+++ b/run-hadd/README.md
@@ -1,7 +1,0 @@
-# Recording total POT in each hadded file
-
-For the spill building stage it is necessary to know the total amount of POT in each hadded file. Unless you have no failed jobs at all, this will not simply be the `ARCUBE_HADD_FACTOR` multiplied by `ARCUBE_EXPOSURE`. At the `hadd` stage, one can set `ARCUBE_USE_GHEP_POT=1`, triggering a macro which calculates the total POT of the hadded file from the GENIE files corresponding to the hadded file's constituent EDEPSIM files. The macro is run by `run_hadd.sh` as compiled c++. The `.exe` must be generated and can be done in one step.
-
-```
-shifter --image=$ARCUBE_CONTAINER --module=none /bin/bash -- ${PWD}/install_hadd.sh
-```

--- a/run-hadd/install_hadd.sh
+++ b/run-hadd/install_hadd.sh
@@ -1,10 +1,35 @@
 #!/usr/bin/env bash
 
+# assume Shifter if ARCUBE_RUNTIME is unset
+export ARCUBE_RUNTIME=${ARCUBE_RUNTIME:-SHIFTER}
+
+
+# Keep track of what container was set before.
+export ORG_ARCUBE_CONTAINER=$ARCUBE_CONTAINER
+export ARCUBE_CONTAINER=mjkramer/sim2x2:ndlar011
+
+
+if [[ "$ARCUBE_RUNTIME" == "SHIFTER" ]]; then
+    # Reload in Shifter
+    if [[ "$SHIFTER_IMAGEREQUEST" != "$ARCUBE_CONTAINER" ]]; then
+        shifter --image=$ARCUBE_CONTAINER --module=none -- "$0" "$@"
+        exit
+    fi
+
+else
+    echo "Unsupported \$ARCUBE_RUNTIME"
+    exit
+fi
+
 
 rm getGhepPOT.exe
 
 
 g++ -o getGhepPOT.exe getGhepPOT.C `root-config --cflags --glibs`
+
+
+# Put back the original container
+export ARCUBE_CONTAINER=$ORG_ARCUBE_CONTAINER
 
 
 exit

--- a/run-ndlar-flow/install_ndlar_flow.sh
+++ b/run-ndlar-flow/install_ndlar_flow.sh
@@ -46,4 +46,9 @@ cd ndlar_flow
 pip install -e .
 cd scripts/proto_nd_scripts
 ./get_proto_nd_input.sh
+# AB August 6th 2024: ../ndlar_scripts only exists in development branch at the moment.
+if [ -d ../ndlar_scripts ]; then
+  cd ../ndlar_scripts
+  ./get_ndlar_input.sh
+fi
 cd ../../..

--- a/run-ndlar-flow/run_ndlar_flow_ndlar.sh
+++ b/run-ndlar-flow/run_ndlar_flow_ndlar.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# By default (i.e. if ARCUBE_RUNTIME isn't set), run on the host
+if [[ -z "$ARCUBE_RUNTIME" || "$ARCUBE_RUNTIME" == "NONE" ]]; then
+    if [[ "$LMOD_SYSTEM_NAME" == "perlmutter" ]]; then
+        module unload python 2>/dev/null
+        module load python/3.11
+    fi
+    source ../util/init.inc.sh
+    source "$ARCUBE_INSTALL_DIR/flow.venv/bin/activate"
+else
+    source ../util/reload_in_container.inc.sh
+    source ../util/init.inc.sh
+    if [[ -n "$ARCUBE_USE_LOCAL_PRODUCT" && "$ARCUBE_USE_LOCAL_PRODUCT" != "0" ]]; then
+        # Allow overriding the container's version
+        source "$ARCUBE_INSTALL_DIR/flow.venv/bin/activate"
+    fi
+fi
+
+inDir=${ARCUBE_OUTDIR_BASE}/run-larnd-sim/$ARCUBE_IN_NAME
+inName=$ARCUBE_IN_NAME.$globalIdx
+inFile=$(realpath $inDir/LARNDSIM/$subDir/${inName}.LARNDSIM.hdf5)
+
+outFile=$tmpOutDir/${outName}.FLOW.hdf5
+rm -f "$outFile"
+
+# charge workflows
+workflow1='yamls/ndlar_flow/workflows/charge/charge_event_building.yaml'
+workflow2='yamls/ndlar_flow/workflows/charge/charge_event_reconstruction.yaml'
+workflow3='yamls/ndlar_flow/workflows/combined/combined_reconstruction.yaml'
+workflow4='yamls/ndlar_flow/workflows/charge/prompt_calibration.yaml'
+workflow5='yamls/ndlar_flow/workflows/charge/final_calibration.yaml'
+
+cd "$ARCUBE_INSTALL_DIR"/ndlar_flow
+
+# Ensure that the second h5flow doesn't run if the first one crashes. This also
+# ensures that we properly report the failure to the production system.
+set -o errexit
+
+# AB August 6th 2024: Like 2x2, not currently running the final calibration.
+#run h5flow -c $workflow1 $workflow2 $workflow3 $workflow4 $workflow5\
+run h5flow -c $workflow1 $workflow2 $workflow3 $workflow4\
+    -i "$inFile" -o "$outFile"
+
+mkdir -p "$outDir/FLOW/$subDir"
+mv "$outFile" "$outDir/FLOW/$subDir"

--- a/run-spill-build/run_spill_build.sh
+++ b/run-spill-build/run_spill_build.sh
@@ -35,8 +35,27 @@ libpath_remove /opt/generators/edep-sim/install/lib
 [ -z "${ARCUBE_SPILL_PERIOD}" ] && export ARCUBE_SPILL_PERIOD=1.2
 
 if [[ "$ARCUBE_USE_GHEP_POT" == "1" ]]; then
-  read -r ARCUBE_NU_POT < "$nuInDir"/POT/"$nuName".pot
-  read -r ARCUBE_ROCK_POT < "$rockInDir"/POT/"$rockName".pot
+  # Covering the case that we want to use the GHEP POT but build only
+  # fiducial or only rock spills. For example, to build fiducial 
+  # only spills, ARCUBE_ROCK_POT is set to zero. 
+  if [[ "$ARCUBE_NU_POT" != "0" && -n "$ARCUBE_NU_POT" ]]; then
+    echo "Setting ARCUBE_NU_POT to a non-zero value while also using GHEP POT via"
+    echo "ARCUBE_USE_GHEP_POT is inconsistent. Please refactor..."
+    exit
+  elif [[ "$ARCUBE_NU_POT" == "0" ]]; then
+    echo "ARCUBE_NU_POT is set to zero - spills will be rock only."
+  else
+    read -r ARCUBE_NU_POT < "$nuInDir"/POT/$subDir/"$nuName".pot
+  fi
+  if [[ "$ARCUBE_ROCK_POT" != "0" && -n "$ARCUBE_ROCK_POT" ]]; then
+    echo "Setting ARCUBE_ROCK_POT to a non-zero value while also using GHEP POT via"
+    echo "ARCUBE_USE_GHEP_POT is inconsistent. Please refactor..."
+    exit
+  elif [[ "$ARCUBE_ROCK_POT" == "0" ]]; then
+    echo "ARCUBE_NU_ROCK is set to zero - spills will be fiducial only."
+  else
+    read -r ARCUBE_ROCK_POT < "$rockInDir"/POT/$subDir/"$rockName".pot
+  fi
 fi
 
 # run root -l -b -q \

--- a/run-validation/edepsim_validation.py
+++ b/run-validation/edepsim_validation.py
@@ -113,6 +113,23 @@ def main(sim_file, input_type, det_complex):
         output.savefig()
         plt.close()
 
+        ### Plot number of hit segments per event id
+        event_ids = np.unique(segments['event_id'])
+        n_segments = np.zeros(event_ids.size)
+        current_evt = 0
+        current_id = segments['event_id'][0]
+        for segment in segments:
+            if segment['event_id'] != current_id:
+                current_id = segment['event_id']
+                current_evt += 1
+            n_segments[current_evt] += 1
+
+        plt.hist(n_segments, bins=100)
+        plt.xlabel(r'N segments')
+        plt.ylabel('Spills')
+        output.savefig()
+        plt.close()
+
         ### Plot dEdx for each segment
         plt.hist(segments['dEdx'], bins=100, range=[0, 100])
         plt.title('dEdx')

--- a/run-validation/flow_validation.py
+++ b/run-validation/flow_validation.py
@@ -13,7 +13,7 @@ rasterize_plots()
 SPILL_PERIOD = 1.2e7 # units = ticks
 RESET_PERIOD = 1.0e7 # units = ticks
 
-def main(flow_file):
+def main(flow_file, charge_only):
 
     flow_h5 = h5py.File(flow_file,'r')
     plt.rcParams["figure.figsize"] = (10,8)
@@ -38,83 +38,84 @@ def main(flow_file):
         hits = flow_h5['/charge/calib_prompt_hits/data']
         final_hits = flow_h5['/charge/calib_final_hits/data']
 
-        ### Event display
-        sipm_hits_data = flow_h5['light/sipm_hits/data']
+        if not charge_only:
+           ### Event display
+           sipm_hits_data = flow_h5['light/sipm_hits/data']
 
-        # Extracting channel IDs and maximum values
-        channel_ids = sipm_hits_data['chan'][:]
-        max_values = sipm_hits_data['max'][:]
-        pos_data = sipm_hits_data['pos'][:]
-        z_coordinates = pos_data[:, 2]
-        x_coordinates = pos_data[:, 0]
-        y_coordinates = pos_data[:, 1]
+           # Extracting channel IDs and maximum values
+           channel_ids = sipm_hits_data['chan'][:]
+           max_values = sipm_hits_data['max'][:]
+           pos_data = sipm_hits_data['pos'][:]
+           z_coordinates = pos_data[:, 2]
+           x_coordinates = pos_data[:, 0]
+           y_coordinates = pos_data[:, 1]
 
-        unique_x, xcounts = np.unique(x_coordinates, return_counts=True)
-        unique_y, ycounts = np.unique(y_coordinates, return_counts=True)
-        unique_z, zcounts = np.unique(z_coordinates, return_counts=True)
+           unique_x, xcounts = np.unique(x_coordinates, return_counts=True)
+           unique_y, ycounts = np.unique(y_coordinates, return_counts=True)
+           unique_z, zcounts = np.unique(z_coordinates, return_counts=True)
 
-        plt.figure(figsize=(10, 6))
-        plt.bar(unique_x, xcounts)
-        plt.xlabel('X-coordinate')
-        plt.ylabel('Counts')
-        plt.title('X-coordinate')
-        plt.grid(True)
-        output.savefig()  
-        plt.close()
+           plt.figure(figsize=(10, 6))
+           plt.bar(unique_x, xcounts)
+           plt.xlabel('X-coordinate')
+           plt.ylabel('Counts')
+           plt.title('X-coordinate')
+           plt.grid(True)
+           output.savefig()  
+           plt.close()
 
-        plt.figure(figsize=(10, 6))
-        plt.bar(unique_y, ycounts)
-        plt.xlabel('Y-coordinate')
-        plt.ylabel('Counts')
-        plt.title('Y-coordinate')
-        plt.grid(True)
-        output.savefig()  
-        plt.close()
+           plt.figure(figsize=(10, 6))
+           plt.bar(unique_y, ycounts)
+           plt.xlabel('Y-coordinate')
+           plt.ylabel('Counts')
+           plt.title('Y-coordinate')
+           plt.grid(True)
+           output.savefig()  
+           plt.close()
  
-        plt.figure(figsize=(10, 6))
-        plt.bar(unique_z, zcounts)
-        plt.xlabel('Z-coordinate')
-        plt.ylabel('Counts')
-        plt.title('Z-coordinate')
-        plt.grid(True)
-        output.savefig()  
-        plt.close()
+           plt.figure(figsize=(10, 6))
+           plt.bar(unique_z, zcounts)
+           plt.xlabel('Z-coordinate')
+           plt.ylabel('Counts')
+           plt.title('Z-coordinate')
+           plt.grid(True)
+           output.savefig()  
+           plt.close()
 
 
-        # Plot scatter plot for channel IDs versus maximum values
-        plt.figure(figsize=(10, 6))
-        plt.scatter(channel_ids, max_values, marker='.', color='blue')
-        plt.xlabel('Channel ID')
-        plt.ylabel('Maximum Value')
-        plt.title('Maximum Values vs. Channel IDs')
-        plt.grid(True)
-        plt.xlim(0, 60)
-        output.savefig()  
-        plt.close()    
+           # Plot scatter plot for channel IDs versus maximum values
+           plt.figure(figsize=(10, 6))
+           plt.scatter(channel_ids, max_values, marker='.', color='blue')
+           plt.xlabel('Channel ID')
+           plt.ylabel('Maximum Value')
+           plt.title('Maximum Values vs. Channel IDs')
+           plt.grid(True)
+           plt.xlim(0, 60)
+           output.savefig()  
+           plt.close()    
 
-        sum_hits_data = flow_h5['light/sum_hits/data']
-        tpc_values = sum_hits_data['tpc'][:]
-        det_values = sum_hits_data['det'][:]
-        unique_tpc, counts_tpc = np.unique(tpc_values, return_counts=True)
-        unique_det, counts_det = np.unique(det_values, return_counts=True)
+           sum_hits_data = flow_h5['light/sum_hits/data']
+           tpc_values = sum_hits_data['tpc'][:]
+           det_values = sum_hits_data['det'][:]
+           unique_tpc, counts_tpc = np.unique(tpc_values, return_counts=True)
+           unique_det, counts_det = np.unique(det_values, return_counts=True)
 
-        plt.figure(figsize=(8, 6))
-        plt.bar(unique_tpc, counts_tpc, color='purple')
-        plt.xlabel('tpc_values')
-        plt.ylabel('Counts')
-        plt.title(f'Histogram of TPC index')
-        plt.grid(True)
-        output.savefig()  
-        plt.close()    
+           plt.figure(figsize=(8, 6))
+           plt.bar(unique_tpc, counts_tpc, color='purple')
+           plt.xlabel('tpc_values')
+           plt.ylabel('Counts')
+           plt.title(f'Histogram of TPC index')
+           plt.grid(True)
+           output.savefig()  
+           plt.close()    
 
-        plt.figure(figsize=(8, 6))
-        plt.bar(unique_det, counts_det, color='purple')
-        plt.xlabel('det_values')
-        plt.ylabel('Counts')
-        plt.title(f'Histogram of detector index')
-        plt.grid(True)
-        output.savefig()  
-        plt.close()   
+           plt.figure(figsize=(8, 6))
+           plt.bar(unique_det, counts_det, color='purple')
+           plt.xlabel('det_values')
+           plt.ylabel('Counts')
+           plt.title(f'Histogram of detector index')
+           plt.grid(True)
+           output.savefig()  
+           plt.close()   
 
 
         # 3D - all spills
@@ -137,6 +138,7 @@ def main(flow_file):
         del ax, fig
         output.savefig()
         plt.close()
+
         # 2D hit projections
         fig = plt.figure(figsize=(10,6))
         gs  = fig.add_gridspec(1,3)
@@ -144,10 +146,12 @@ def main(flow_file):
         ax2 = fig.add_subplot(gs[0,1],aspect=1.0)
         ax3 = fig.add_subplot(gs[0,2],aspect=1.0)
 
-        for iog in range(1,9,1):
+        io_group_count = 1
+        io_groups_uniq = set(hits['io_group'])
+        for iog in io_groups_uniq:
             iog_mask = hits['io_group'] == iog
             iog_hits = hits[iog_mask]      
-            ax1.scatter(iog_hits['z'],iog_hits['y'],s=0.5,alpha=0.1,label='IO Group'+str(iog))
+            ax1.scatter(iog_hits['z'],iog_hits['y'],s=0.5,alpha=0.1,label='IO Group '+str(iog))
             ax1.set_xlabel(r'z [cm]')
             ax1.set_ylabel(r'y [cm]')
 
@@ -159,12 +163,21 @@ def main(flow_file):
             ax3.set_xlabel(r'x [cm]')
             ax3.set_ylabel(r'y [cm]')
 
-        leg = fig.legend(bbox_to_anchor=(0.2, 0.8), loc='lower left', ncols=4, markerscale=10.,fontsize=13)
-        for lh in leg.legend_handles:
-            lh.set_alpha(1)
-        plt.tight_layout()
-        output.savefig()
-        plt.close()
+            if io_group_count % 8 == 0 or io_group_count == len(io_groups_uniq):
+                leg = fig.legend(bbox_to_anchor=(0.2, 0.8), loc='lower left', ncols=4, markerscale=10.,fontsize=13)
+                for lh in leg.legend_handles:
+                    lh.set_alpha(1)
+                plt.tight_layout()
+                output.savefig()
+                plt.close()
+
+                fig = plt.figure(figsize=(10,6))
+                gs  = fig.add_gridspec(1,3)
+                ax1 = fig.add_subplot(gs[0,0],aspect=1.0)
+                ax2 = fig.add_subplot(gs[0,1],aspect=1.0)
+                ax3 = fig.add_subplot(gs[0,2],aspect=1.0)
+                
+            io_group_count += 1
 
         ### Hit level 1D position distributions
         fig = plt.figure(figsize=(10,10),layout="constrained")
@@ -195,51 +208,51 @@ def main(flow_file):
         plt.close()
 
         # 3D - "event" spills
-        fig = plt.figure(figsize=(10,10),layout="constrained")
-        ax = fig.add_subplot(projection='3d')
-        ax.set_facecolor('none')
         n_evts = len(flow_h5['charge/events/ref/charge/calib_final_hits/ref_region'])
-        io_group_contrib = np.zeros(shape=(n_evts,8))
+        io_group_contrib = np.zeros(shape=(n_evts,len(io_groups_uniq)))
         for a in range(n_evts):
+            fig = plt.figure(figsize=(10,10),layout="constrained")
+            ax = fig.add_subplot(projection='3d')
+            ax.set_facecolor('none')
             hit_ref_slice = flow_h5['charge/events/ref/charge/calib_final_hits/ref_region'][a]
             spill_hits = final_hits[hit_ref_slice[0]:hit_ref_slice[1]]
             event_charge = np.sum(spill_hits['Q'])
-            for iog in range(8):
-                iog_mask = spill_hits['io_group'] == (iog+1)
+            if event_charge==0:
+                plt.close()
+                continue
+            for iog in io_groups_uniq:
+                iog_mask = spill_hits['io_group'] == iog
                 iog_hits = spill_hits[iog_mask]
                 iog_evt_charge = 0.
                 if len(iog_hits) > 0:
                     iog_evt_charge = np.sum(iog_hits['Q'])
-                try:
-                    io_group_contrib[a][iog] = float(iog_evt_charge)/float(event_charge)
-                except ZeroDivisionError:
-                    io_group_contrib[a][iog] = 0.
+                io_group_contrib[a][int(iog-1)] = float(iog_evt_charge)/float(event_charge)
             dat = ax.scatter(spill_hits['z'],spill_hits['x'],
                        spill_hits['y'],c=spill_hits['Q'],
                        s=1,cmap='viridis',norm=mlp.colors.LogNorm())
-        ax.set_title(f"Hits in charge events",fontsize=24)
-        ax.set_xlabel('z [cm]',fontsize=16)
-        ax.set_ylabel('x [cm]',fontsize=16)
-        ax.set_zlabel('y [cm]',fontsize=16)
-        ax.set_xlim([-65.,65])
-        ax.set_ylim([-65.,65])
-        ax.set_zlim([-65.,65])
-        output.savefig()
-        plt.close()
+            ax.set_title(f"Hits in charge events",fontsize=24)
+            ax.set_xlabel('z [cm]',fontsize=16)
+            ax.set_ylabel('x [cm]',fontsize=16)
+            ax.set_zlabel('y [cm]',fontsize=16)
+            ##ax.set_xlim([-65.,65])
+            ##ax.set_ylim([-65.,65])
+            ##ax.set_zlim([-65.,65])
+            output.savefig()
+            plt.close()
 
         # io_group contribution for each spill
         fig = plt.figure(figsize=(10,8))
         ax = fig.add_subplot()
         ax.set_facecolor('none')
         bottom = np.zeros(n_evts)
-        for iog in range(8):
-            iog_cont = (io_group_contrib[:,iog:(iog+1)]).flatten()
-            ax.bar(range(n_evts), iog_cont, bottom=bottom, label='IO Group '+str(iog+1), width=1.0)
+        for iog in io_groups_uniq:
+            iog_cont = (io_group_contrib[:,int(iog-1):iog]).flatten()
+            ax.bar(range(n_evts), iog_cont, bottom=bottom, label='IO Group '+str(iog), width=1.0)
             bottom += iog_cont
-        ax.legend(ncols=4,fontsize=13)
+        #ax.legend(ncols=4,fontsize=13)
         ax.set_xlabel('charge event number',fontsize=18)
         ax.set_ylabel('io_group contribution',fontsize=18)
-        ax.set_ylim([-0.1,1.5])
+        #ax.set_ylim([-0.1,1.5])
         del ax, fig
         output.savefig()
         plt.close()
@@ -299,9 +312,9 @@ def main(flow_file):
             ax[a].set_xlabel('z [cm]')
             ax[a].set_ylabel('x [cm]')
             ax[a].set_zlabel('y [cm]')
-            ax[a].set_xlim([-65.,65])
-            ax[a].set_ylim([-65.,65])
-            ax[a].set_zlim([-65.,65])
+            #ax[a].set_xlim([-65.,65])
+            #ax[a].set_ylim([-65.,65])
+            #ax[a].set_zlim([-65.,65])
         output.savefig()
         plt.close()
 
@@ -343,6 +356,7 @@ def main(flow_file):
         other_packet_mask= ~(data_packet_mask | trig_packet_mask | sync_packet_mask)
 
         ### Plot time structure of packets: 
+        plt.clf()
         plt.plot(packets['timestamp'][data_packet_mask],packet_index[data_packet_mask],'o',label='data packets',linestyle='None')
         plt.plot(packets['timestamp'][trig_packet_mask],packet_index[trig_packet_mask],'o',label='lrs triggers',linestyle='None')
         plt.plot(packets['timestamp'][sync_packet_mask],packet_index[sync_packet_mask],'o',label='PPS packets',linestyle='None')
@@ -380,13 +394,17 @@ def main(flow_file):
         plt.close()
 
         ### Plot charge vs. time per io_group/tpc
-        for iog in range(1,9,1):
+        packets_stack = []
+        weights_stack = []
+        for iog in io_groups_uniq:
             iog_mask = (packets['io_group'] == iog) & data_packet_mask
-            plt.hist(packets['timestamp'][iog_mask]%(SPILL_PERIOD%RESET_PERIOD),weights=packets['dataword'][iog_mask],bins=200,label='io_group '+str(iog),alpha=0.5)
+            packets_stack.append(packets['timestamp'][iog_mask]%(SPILL_PERIOD%RESET_PERIOD))
+            weights_stack.append(packets['dataword'][iog_mask])
+        plt.hist(packets_stack, weights=weights_stack, stacked=True, bins=200, label='io_group '+str(iog),alpha=0.5)
         plt.title('/charge/packets/data')
-        plt.xlabel('timestamp%spill_period')
+        plt.xlabel('timestamp%(spill_period%reset_period)')
         plt.ylabel('charge [ADC]')
-        plt.legend(ncol=4,bbox_to_anchor=(-0.05,1.00),loc='lower left')
+        #plt.legend(ncol=4,bbox_to_anchor=(-0.05,1.00),loc='lower left')
         output.savefig()
         plt.close()
 
@@ -440,8 +458,8 @@ def main(flow_file):
         output.savefig()
         plt.close()
         
-        #ax4.hist(f['charge/calib_prompt_hits/data']['ts_pps'],bins=100,alpha=0.5,label='prompt hits')
-        #ax4.hist(f['charge/calib_final_hits/data']['ts_pps'],bins=100,alpha=0.5,label='merged hits')
+        #ax4.hist(flow_h5['charge/calib_prompt_hits/data']['ts_pps'],bins=100,alpha=0.5,label='prompt hits')
+        #ax4.hist(flow_h5['charge/calib_final_hits/data']['ts_pps'],bins=100,alpha=0.5,label='merged hits')
         #ax4.set_xlabel('ts_pps [ticks = 0.1 us]')
         #ax4.set_ylabel('N hits')
         #ax4.legend()
@@ -456,40 +474,38 @@ def main(flow_file):
             # Histograms of io_group in hits and packet datasets
             ax1.set_ylim(0,30000)
             ax1.hist(packets_hits['io_group'], 
-                     label="packets", bins=8, 
+                     label="packets", bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1), 
                      alpha=1.0, color='#377eb8', 
                      edgecolor='#377eb8', linestyle='-')
             ax1.hist(hits['io_group'], 
-                     label="calib_prompt_hits", bins=8, 
+                     label="calib_prompt_hits", bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1),
                      alpha=1.0, color='#ff7f00', 
                      edgecolor='#ff7f00', linestyle='-', 
                      linewidth=1.5,fill=False)
             ax1.hist(final_hits['io_group'], 
-                     label="calib_final_hits", bins=8, 
+                     label="calib_final_hits", bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1),
                      alpha=0.8, color='#4daf4a', 
                      edgecolor='#4daf4a', linestyle='--', 
                      linewidth=1.5,fill=False)
             ax1.set_title("Hits per IO Group Distribution in Different Datasets")
             ax1.set_xlabel("IO Group")
-            ax1.set_xlim(1,8)
             ax1.set_ylabel("Hits / IO Group")
             ax1.legend()
 
-            p_iog, p_iog_bins = np.histogram(hits['io_group'], bins=8)
-            f_iog, f_iog_bins = np.histogram(final_hits['io_group'], bins=8)
+            p_iog, p_iog_bins = np.histogram(hits['io_group'], bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1),)
+            f_iog, f_iog_bins = np.histogram(final_hits['io_group'], bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1),)
             iog_resid = 100*(p_iog - f_iog)/p_iog
             mean_iog_resid = np.mean(iog_resid)
             final_prompt_resid = 100*(len(hits['io_group']) - len(final_hits['io_group']))/len(hits['io_group'])
 
             ax2.set_ylim(0,np.max(iog_resid)+10)
-            ax2.set_xlim(1,8)
-            ax2.plot(np.arange(80)-5, np.ones(80)*mean_iog_resid, \
+            ax2.plot(np.arange(len(io_groups_uniq)+1)+1, np.ones(len(io_groups_uniq)+1)*mean_iog_resid, \
                      linestyle='--', color='blue', \
                      label="Mean % Decr. over IO Groups ("+str(round(mean_iog_resid, 1))+"%)")
-            ax2.plot(np.arange(80)-5, np.ones(80)*final_prompt_resid, \
+            ax2.plot(np.arange(len(io_groups_uniq)+1)+1, np.ones(len(io_groups_uniq)+1)*final_prompt_resid, \
                      linestyle='--', color='black', \
                      label="Total % Decr. Prompt to Final Hits ("+str(round(final_prompt_resid, 1))+"%)")
-            ax2.hist(np.arange(8)+1.0, weights=iog_resid, bins=8,
+            ax2.hist(np.arange(len(io_groups_uniq))+1, weights=iog_resid, bins=len(io_groups_uniq), range=(1, len(io_groups_uniq)+1),
                     alpha=1.0, color='#f781bf', 
                     edgecolor='#f781bf', linestyle='-', 
                     linewidth=1.5)
@@ -509,19 +525,19 @@ def main(flow_file):
             ax2 = fig.add_subplot(gs[1,0])
 
             # Histograms of io_channel in hits datasets
+            io_channel_uniq = set(packets_hits['io_channel'])
             ax1.set_ylim(0,12000)
-            ax1.set_xlim(1,32)
             ax1.hist(packets_hits['io_channel'], 
-                     label="packets", bins=32, 
+                     label="packets", bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1),
                      alpha=1.0, color='#377eb8', 
                      edgecolor='#377eb8', linestyle='-')
             ax1.hist(hits['io_channel'], 
-                     label="calib_prompt_hits", bins=32, 
+                     label="calib_prompt_hits", bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1),
                      alpha=1.0, color='#ff7f00', 
                      edgecolor='#ff7f00', linestyle='-', 
                      linewidth=1.5,fill=False)
             ax1.hist(final_hits['io_channel'], 
-                     label="calib_final_hits", bins=32, 
+                     label="calib_final_hits", bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1), 
                      alpha=0.8, color='#4daf4a', 
                      edgecolor='#4daf4a', linestyle='--', 
                      linewidth=1.5,fill=False)
@@ -530,20 +546,19 @@ def main(flow_file):
             ax1.set_ylabel("Hits / IO Channel")
             ax1.legend()
 
-            p_io_channel, p_io_channel_bins = np.histogram(hits['io_channel'], bins=32)
-            f_io_channel, f_io_channel_bins = np.histogram(final_hits['io_channel'], bins=32)
+            p_io_channel, p_io_channel_bins = np.histogram(hits['io_channel'], bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1))
+            f_io_channel, f_io_channel_bins = np.histogram(final_hits['io_channel'], bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1))
             io_channel_resid = 100* (p_io_channel - f_io_channel)/p_io_channel
             mean_io_channel_resid = np.mean(io_channel_resid)
 
             ax2.set_ylim(0,np.max(io_channel_resid)+10)
-            ax2.set_xlim(1,32)
-            ax2.plot(np.arange(80)-5, np.ones(80)*mean_io_channel_resid, \
+            ax2.plot(np.arange(len(io_channel_uniq)+1)+1, np.ones(len(io_channel_uniq)+1)*mean_io_channel_resid, \
                      linestyle='--', color='blue', \
                      label="Mean % Decr. over IO Channels ("+str(round(mean_io_channel_resid, 1))+"%)")
-            ax2.plot(np.arange(80)-5, np.ones(80)*final_prompt_resid, \
+            ax2.plot(np.arange(len(io_channel_uniq)+1)+1, np.ones(len(io_channel_uniq)+1)*final_prompt_resid, \
                      linestyle='--', color='black', \
                      label="Total % Decr. Prompt to Final Hits ("+str(round(final_prompt_resid, 1))+"%)")
-            ax2.hist(np.arange(32)+1.0, weights=io_channel_resid, bins=32,
+            ax2.hist(np.arange(len(io_channel_uniq))+1, weights=io_channel_resid, bins=len(io_channel_uniq), range=(1, len(io_channel_uniq)+1),
                      alpha=1.0, color='#f781bf', 
                      edgecolor='#f781bf', linestyle='-', 
                      linewidth=1.5)
@@ -558,6 +573,7 @@ def main(flow_file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--flow_file', default=None, type=str,help='''string corresponding to the path of the ndlar_flow output file to be considered''')
+    parser.add_argument('--charge_only', action='store_true', help='''boolean to flag that light has not been simualted''')
     args = parser.parse_args()
     main(**vars(args))
 

--- a/run-validation/larndsim_validation.py
+++ b/run-validation/larndsim_validation.py
@@ -134,7 +134,6 @@ def main(sim_file, charge_only):
            
             # Minus 2 here because we skipped io_group 0.
             if io_group_count % io_groups_per_page == io_groups_per_page-1 or io_group_count == len(io_groups_uniq)-2:
-                print(io_group_count)
                 plt.xlabel('timestamp%(spill_period%reset_period)')
                 plt.ylabel('charge [ADC]')
                 plt.legend(ncol=2,bbox_to_anchor=(-0.05,1.00),loc='lower left')

--- a/run-validation/larndsim_validation.py
+++ b/run-validation/larndsim_validation.py
@@ -9,6 +9,7 @@ import numpy as np
 import awkward as ak
 import h5py
 import argparse
+import sys
 from matplotlib.backends.backend_pdf import PdfPages
 
 from validation_utils import rasterize_plots
@@ -16,7 +17,7 @@ rasterize_plots()
 
 SPILL_PERIOD = 1.2e7 # units = ticks
 
-def main(sim_file):
+def main(sim_file, charge_only):
 
     sim_h5 = h5py.File(sim_file,'r')
     print('\n----------------- File content -----------------')
@@ -40,37 +41,45 @@ def main(sim_file):
         timestamp_packet_mask = packets['packet_type'] == 4
         sync_packet_mask = (packets['packet_type'] == 6) & (packets['trigger_type'] == 83)
         other_packet_mask= ~(data_packet_mask | trig_packet_mask | sync_packet_mask | timestamp_packet_mask)
+        io_groups_uniq = set(packets['io_group'])
 
         ### Plot time structure of packets: 
-        fig = plt.figure(figsize=(10,10))
-        gs = fig.add_gridspec(ncols=1,nrows=8)
-        fig.subplots_adjust(left=0.075,bottom=0.075,wspace=None, hspace=0.)
-        ax = []
-        for iog in range(8):
-            if iog==0: ax.append(fig.add_subplot(gs[iog,0]))
-            else: ax.append(fig.add_subplot(gs[iog,0],sharex=ax[0]))
+        io_group_count = 0
+        io_groups_per_page = 8
+        for iog in io_groups_uniq:
+            
+            if io_group_count % io_groups_per_page == 0:
+                fig = plt.figure(figsize=(10,10))
+                gs = fig.add_gridspec(ncols=1,nrows=io_groups_per_page)
+                fig.subplots_adjust(left=0.075,bottom=0.075,wspace=None, hspace=0.)
+                ax = []
+                ax.append(fig.add_subplot(gs[iog % io_groups_per_page,0]))
+            else: ax.append(fig.add_subplot(gs[iog % io_groups_per_page,0],sharex=ax[0]))
+
             iog_mask = packets['io_group'] == iog+1
             temp_mask = np.logical_and(iog_mask,data_packet_mask)
-            ax[iog].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='data packets',linestyle='None',ms=2)
+            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='data packets',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,trig_packet_mask)
-            ax[iog].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='lrs triggers',linestyle='None',ms=2)
+            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='lrs triggers',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,sync_packet_mask)
-            ax[iog].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='PPS packets',linestyle='None',ms=2)
+            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='PPS packets',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,other_packet_mask)
-            ax[iog].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='other',linestyle='None',ms=2)
+            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='other',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,timestamp_packet_mask)
-            ax[iog].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='timestamp packets',linestyle='None',ms=2)
-            ax[iog].grid()
-            temp_ax = ax[iog].twinx()
+            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='timestamp packets',linestyle='None',ms=2)
+            ax[iog % io_groups_per_page].grid()
+            temp_ax = ax[iog % io_groups_per_page].twinx()
             temp_ax.set_ylabel('io_group = '+str(iog+1))
             temp_ax.tick_params(labelright=False)
             temp_ax.tick_params(axis='y',rotation=180)
 
-        for i in range(0,7,1): ax[i].tick_params(labelbottom=False)
-        ax[7].set_xlabel('packet index',fontsize=10) 
-        ax[3].set_ylabel('packet timestamp',fontsize=10)
-        output.savefig()
-        plt.close()
+            if io_group_count % 8 == 7 or io_group_count == len(io_groups_uniq)-1:
+                for i in range(0,len(ax)-1): ax[i].tick_params(labelbottom=False)
+                ax[len(ax)-1].set_xlabel('packet index',fontsize=10) 
+                ax[len(ax)//2].set_ylabel('packet timestamp',fontsize=10)
+                output.savefig()
+                plt.close()
+            io_group_count += 1
 
         plt.plot(packet_index[data_packet_mask],packets['timestamp'][data_packet_mask],'o',label='data packets',linestyle='None',ms=1)
         plt.plot(packet_index[trig_packet_mask],packets['timestamp'][trig_packet_mask],'o',label='lrs triggers',linestyle='None',ms=1)
@@ -105,12 +114,29 @@ def main(sim_file):
         plt.close()
 
         ### Plot charge vs. time per io_group/tpc
-        for iog in range(1,9,1):
+        io_group_count = 1
+        packets_stack = []
+        weights_stack = []
+        for iog in io_groups_uniq:
             iog_mask = (packets['io_group'] == iog) & data_packet_mask
+            packets_stack.append(packets['timestamp'][iog_mask]%SPILL_PERIOD)
+            weights_stack.append(packets['dataword'][iog_mask])
             plt.hist(packets['timestamp'][iog_mask]%SPILL_PERIOD,weights=packets['dataword'][iog_mask],bins=200,label='io_group '+str(iog),alpha=0.5)
+           
+            # Four io_groups per plot.
+            if io_group_count % 4 == 0 or io_group_count == len(io_groups_uniq):
+                plt.xlabel('timestamp%spill_period')
+                plt.ylabel('charge [ADC]')
+                plt.legend(ncol=2,bbox_to_anchor=(-0.05,1.00),loc='lower left')
+                output.savefig()
+                plt.close()
+
+            io_group_count += 1
+
+        ### Plot charge vs. time
+        plt.hist(packets_stack,weights=weights_stack,stacked=True,bins=200,alpha=0.5)
         plt.xlabel('timestamp%spill_period')
         plt.ylabel('charge [ADC]')
-        plt.legend(ncol=4,bbox_to_anchor=(-0.05,1.00),loc='lower left')
         output.savefig()
         plt.close()
 
@@ -172,9 +198,10 @@ def main(sim_file):
         output.savefig()
         plt.close()     
         
+        if charge_only: sys.exit(0)
         # Now we validate the light simulation:
         # For questions on the light validations below, see DUNE ND Prototype Workshop (May 2023) Coding Tutorial, 
-        # or message Angela White on the DUNE Slack
+        # or message Angela White on the DUNE Slack. Not yet looked at for a full NDLAr geometry.
         
         # Account for the timestamp turnover:
         light_trig = sim_h5['light_trig']
@@ -580,6 +607,7 @@ def main(sim_file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--sim_file', default=None, type=str,help='''string corresponding to the path of the larnd-sim output simulation file to be considered''')
+    parser.add_argument('--charge_only', action='store_true', help='''boolean to flag that light has not been simualted''')
     args = parser.parse_args()
     main(**vars(args))
 

--- a/run-validation/larndsim_validation.py
+++ b/run-validation/larndsim_validation.py
@@ -16,6 +16,7 @@ from validation_utils import rasterize_plots
 rasterize_plots()
 
 SPILL_PERIOD = 1.2e7 # units = ticks
+RESET_PERIOD = 1.0e7 # units = ticks
 
 def main(sim_file, charge_only):
 
@@ -47,34 +48,38 @@ def main(sim_file, charge_only):
         io_group_count = 0
         io_groups_per_page = 8
         for iog in io_groups_uniq:
+            # Skip io_group 0.
+            if iog == 0: continue
             
             if io_group_count % io_groups_per_page == 0:
                 fig = plt.figure(figsize=(10,10))
                 gs = fig.add_gridspec(ncols=1,nrows=io_groups_per_page)
                 fig.subplots_adjust(left=0.075,bottom=0.075,wspace=None, hspace=0.)
                 ax = []
-                ax.append(fig.add_subplot(gs[iog % io_groups_per_page,0]))
-            else: ax.append(fig.add_subplot(gs[iog % io_groups_per_page,0],sharex=ax[0]))
+                ax.append(fig.add_subplot(gs[io_group_count % io_groups_per_page,0]))
+            else: ax.append(fig.add_subplot(gs[io_group_count % io_groups_per_page,0],sharex=ax[0]))
 
-            iog_mask = packets['io_group'] == iog+1
+            iog_mask = packets['io_group'] == iog
             temp_mask = np.logical_and(iog_mask,data_packet_mask)
-            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='data packets',linestyle='None',ms=2)
+            ax[io_group_count % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='data packets',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,trig_packet_mask)
-            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='lrs triggers',linestyle='None',ms=2)
+            ax[io_group_count % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='lrs triggers',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,sync_packet_mask)
-            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='PPS packets',linestyle='None',ms=2)
+            ax[io_group_count % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='PPS packets',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,other_packet_mask)
-            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='other',linestyle='None',ms=2)
+            ax[io_group_count % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='other',linestyle='None',ms=2)
             temp_mask = np.logical_and(iog_mask,timestamp_packet_mask)
-            ax[iog % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='timestamp packets',linestyle='None',ms=2)
-            ax[iog % io_groups_per_page].grid()
-            temp_ax = ax[iog % io_groups_per_page].twinx()
-            temp_ax.set_ylabel('io_group = '+str(iog+1))
+            ax[io_group_count % io_groups_per_page].plot(packet_index[temp_mask],packets['timestamp'][temp_mask],'o',label='timestamp packets',linestyle='None',ms=2)
+            ax[io_group_count % io_groups_per_page].grid()
+            temp_ax = ax[io_group_count % io_groups_per_page].twinx()
+            temp_ax.set_ylabel('io_group = '+str(iog))
             temp_ax.tick_params(labelright=False)
             temp_ax.tick_params(axis='y',rotation=180)
 
-            if io_group_count % 8 == 7 or io_group_count == len(io_groups_uniq)-1:
+            # Minus 2 here because we skipped io_group 0.
+            if io_group_count % io_groups_per_page == io_groups_per_page-1 or io_group_count == len(io_groups_uniq)-2:
                 for i in range(0,len(ax)-1): ax[i].tick_params(labelbottom=False)
+                #for i in range(0,len(ax)-1): ax[i].set_xlim(0, 1e6)
                 ax[len(ax)-1].set_xlabel('packet index',fontsize=10) 
                 ax[len(ax)//2].set_ylabel('packet timestamp',fontsize=10)
                 output.savefig()
@@ -114,18 +119,23 @@ def main(sim_file, charge_only):
         plt.close()
 
         ### Plot charge vs. time per io_group/tpc
-        io_group_count = 1
         packets_stack = []
         weights_stack = []
+        io_group_count = 0
+        io_groups_per_page = 4
         for iog in io_groups_uniq:
+            # Skip io_group 0.
+            if iog == 0: continue
+
             iog_mask = (packets['io_group'] == iog) & data_packet_mask
-            packets_stack.append(packets['timestamp'][iog_mask]%SPILL_PERIOD)
+            packets_stack.append(packets['timestamp'][iog_mask]%(SPILL_PERIOD%RESET_PERIOD))
             weights_stack.append(packets['dataword'][iog_mask])
-            plt.hist(packets['timestamp'][iog_mask]%SPILL_PERIOD,weights=packets['dataword'][iog_mask],bins=200,label='io_group '+str(iog),alpha=0.5)
+            plt.hist(packets['timestamp'][iog_mask]%(SPILL_PERIOD%RESET_PERIOD),weights=packets['dataword'][iog_mask],bins=200,label='io_group '+str(iog),alpha=0.5)
            
-            # Four io_groups per plot.
-            if io_group_count % 4 == 0 or io_group_count == len(io_groups_uniq):
-                plt.xlabel('timestamp%spill_period')
+            # Minus 2 here because we skipped io_group 0.
+            if io_group_count % io_groups_per_page == io_groups_per_page-1 or io_group_count == len(io_groups_uniq)-2:
+                print(io_group_count)
+                plt.xlabel('timestamp%(spill_period%reset_period)')
                 plt.ylabel('charge [ADC]')
                 plt.legend(ncol=2,bbox_to_anchor=(-0.05,1.00),loc='lower left')
                 output.savefig()
@@ -135,7 +145,7 @@ def main(sim_file, charge_only):
 
         ### Plot charge vs. time
         plt.hist(packets_stack,weights=weights_stack,stacked=True,bins=200,alpha=0.5)
-        plt.xlabel('timestamp%spill_period')
+        plt.xlabel('timestamp%(spill_period%reset_period)')
         plt.ylabel('charge [ADC]')
         output.savefig()
         plt.close()


### PR DESCRIPTION
Similar to PR #52, some minor but important updates related to the full ND geometry workflow. 

Everything here should be completely transparent for 2x2. Potentially influential for 2x2 are the changes in validation scripts for `larnd-sim` and `flow` where they have been made IO group and IO channel agnostic. I have tested that all original behaviour is retained using 2x2 input. Proof of that can be found in the files `MiniRun*.pdf` in [docdb-31528](https://docs.dunescience.org/cgi-bin/private/ShowDocument?docid=31528). There is also one more plot in the `edepsim` level validation script.

Other changes / additions:

- The `USE_GHEP_POT` feature for hadding and spill building requires an executable to be built. I have now added an install script consistent with those in other packages and made the necessary additions to the `install_everything`.
- Related to this, a PR I made some time ago allowing fiducial only or rock only spill building broke the `USE_GHEP_POT` feature, have now fixed the spill building run script.
- Paired with [PR 107](https://github.com/DUNE/ndlar_flow/pull/107) in the `ndlar_flow` package, add a few lines using a "getting" script to the flow install script.
- Added a full NDLAr flow workflow `run_` script.