### PR TITLE
Minor change in `ndlar` SPINE config

### DIFF
--- a/run-mlreco/configs/ndlar_full_chain_flash_nersc_240819.cfg
+++ b/run-mlreco/configs/ndlar_full_chain_flash_nersc_240819.cfg
@@ -482,11 +482,11 @@ post:
     update_primaries: false
     priority: 1
   containment:
-    detector: dunend
+    detector: ndlar
     margin: 5.0
     mode: detector
   fiducial:
-    detector: dunend
+    detector: ndlar
     margin: 15.0
     mode: detector
   children_count:


### PR DESCRIPTION
This keeps the `MicroProdN1.1` tag in step with changes in SPINE. Completely NDLAr specific, I'll leave this PR open for 15 mins while I walk to the workshop and merge on arrival if no objections by that time.