### PR TITLE
Generalisations and SPINE related additions to `run-cafmaker`

### DIFF
--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -48,6 +48,7 @@ def main():
     ap.add_argument('--cfg-file', required=True)
     ap.add_argument('--file-id', required=True, type=int)
     ap.add_argument('--hadd-factor', required=False, default=10, type=int)
+    ap.add_argument('--extra-lines', required=False, nargs='*')
     args = ap.parse_args()
 
     if not args.ghep_nu_name and not args.ghep_rock_name:
@@ -72,7 +73,7 @@ def main():
         outf.write(f'nd_cafmaker.CAFMakerSettings.OutputFile: "{caf_path}"\n')
 
         spine_path = get_path(args.base_dir, 'run-spine', args.spine_name,
-                               'MLRECO_ANALYSIS', 'hdf5', args.file_id)
+                               'MLRECO_SPINE', 'hdf5', args.file_id)
         outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{spine_path}"\n')
 
         if args.minerva_name:
@@ -88,6 +89,10 @@ def main():
         edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
                                 'EDEPSIM_SPILLS','root',args.file_id) 
         outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
+
+        if args.extra_lines:
+            for extra_line in args.extra_lines: 
+                outf.write(f'{extra_line}\n')
 
 if __name__ == '__main__':
     main()

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -43,12 +43,12 @@ def main():
     ap.add_argument('--spine-name', required=True)
     ap.add_argument('--tmsreco-name', required=False)
     ap.add_argument('--minerva-name', required=False)
-    ap.add_argument('--edepsim-name', required=False)
+    ap.add_argument('--edepsim-name', required=True)
     ap.add_argument('--caf-path', required=True)
     ap.add_argument('--cfg-file', required=True)
     ap.add_argument('--file-id', required=True, type=int)
     ap.add_argument('--hadd-factor', required=False, default=10, type=int)
-    ap.add_argument('--extra-lines', required=False, nargs='*')
+    ap.add_argument('--extra-lines', required=False, type=str, help="A semi-colon seperated list of arbitrary extra line to be appended to the fhicl.")
     args = ap.parse_args()
 
     if not args.ghep_nu_name and not args.ghep_rock_name:
@@ -72,7 +72,7 @@ def main():
         caf_path = args.caf_path
         outf.write(f'nd_cafmaker.CAFMakerSettings.OutputFile: "{caf_path}"\n')
 
-        spine_path = get_path(args.base_dir, 'run-spine', args.spine_name,
+        spine_path = get_path(args.base_dir, 'run-mlreco', args.spine_name,
                                'MLRECO_SPINE', 'hdf5', args.file_id)
         outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{spine_path}"\n')
 

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -4,8 +4,6 @@ import argparse
 import os
 
 
-HADD_FACTOR = 10
-
 PREAMBLE = """\
 #include "NDCAFMaker.fcl"
 
@@ -27,10 +25,10 @@ def get_path(base_dir, step, name, ftype, ext, file_id: int):
     return path
 
 
-def write_ghep_files(outf, base_dir, name, file_id: int, no_final_comma=False):
-    for ghep_id in range(file_id * HADD_FACTOR, (file_id+1) * HADD_FACTOR):
+def write_ghep_files(outf, base_dir, name, hadd_factor, file_id: int, no_final_comma=False):
+    for ghep_id in range(file_id * hadd_factor, (file_id+1) * hadd_factor):
         path = get_path(base_dir, 'run-genie', name, 'GHEP', 'root', ghep_id)
-        is_last = ghep_id == (file_id+1) * HADD_FACTOR - 1
+        is_last = ghep_id == (file_id+1) * hadd_factor - 1
         maybe_comma = '' if (no_final_comma and is_last) else ','
         outf.write(f'   "{path}"{maybe_comma}\n')
 
@@ -38,23 +36,29 @@ def write_ghep_files(outf, base_dir, name, file_id: int, no_final_comma=False):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--base-dir', required=True)
-    ap.add_argument('--ghep-nu-name', required=True)
-    ap.add_argument('--ghep-rock-name', required=True)
+    ap.add_argument('--ghep-nu-name', required=False)
+    ap.add_argument('--ghep-rock-name', required=False)
     ap.add_argument('--mlreco-name', required=True)
-    ap.add_argument('--minerva-name', required=True)
+    ap.add_argument('--minerva-name', required=False)
     ap.add_argument('--caf-path', required=True)
     ap.add_argument('--cfg-file', required=True)
     ap.add_argument('--file-id', required=True, type=int)
+    ap.add_argument('--hadd-factor', required=False, default=10, type=int)
     args = ap.parse_args()
+
+    if not args.ghep_nu_name and not args.ghep_rock_name:
+        raise ValueError("One or both of ghep-nu-name and ghep-rock-name must be specified")
 
     with open(args.cfg_file, 'w') as outf:
         outf.write(PREAMBLE)
 
         outf.write('nd_cafmaker.CAFMakerSettings.GHEPFiles: [\n')
-        write_ghep_files(outf, args.base_dir, args.ghep_nu_name, args.file_id)
-        outf.write('\n')
-        write_ghep_files(outf, args.base_dir, args.ghep_rock_name, args.file_id,
-                         no_final_comma=True)
+        if args.ghep_nu_name:
+            write_ghep_files(outf, args.base_dir, args.ghep_nu_name, args.hadd_factor, args.file_id, not args.ghep_rock_name)
+            outf.write('\n')
+        if args.ghep_rock_name:
+            write_ghep_files(outf, args.base_dir, args.ghep_rock_name, args.hadd_factor, args.file_id,
+                             no_final_comma=True)
         outf.write(']\n\n')
 
         ## We pass the full CAF path since we initially output to a tmpdir
@@ -67,9 +71,10 @@ def main():
                                'MLRECO_ANA', 'hdf5', args.file_id)
         outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{mlreco_path}"\n')
 
-        minerva_path = get_path(args.base_dir, 'run-minerva', args.minerva_name,
-                                'DST', 'root', args.file_id)
-        outf.write(f'nd_cafmaker.CAFMakerSettings.MINERVARecoFile: "{minerva_path}"\n')
+        if args.minerva_name:
+            minerva_path = get_path(args.base_dir, 'run-minerva', args.minerva_name,
+                                    'DST', 'root', args.file_id)
+            outf.write(f'nd_cafmaker.CAFMakerSettings.MINERVARecoFile: "{minerva_path}"\n')
 
 
 if __name__ == '__main__':

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -39,6 +39,7 @@ def main():
     ap.add_argument('--ghep-nu-name', required=False)
     ap.add_argument('--ghep-rock-name', required=False)
     ap.add_argument('--mlreco-name', required=True)
+    ap.add_argument('--tmsreco-name', required=False)
     ap.add_argument('--minerva-name', required=False)
     ap.add_argument('--caf-path', required=True)
     ap.add_argument('--cfg-file', required=True)
@@ -76,6 +77,10 @@ def main():
                                     'DST', 'root', args.file_id)
             outf.write(f'nd_cafmaker.CAFMakerSettings.MINERVARecoFile: "{minerva_path}"\n')
 
+        if args.tmsreco_name:
+            tmsreco_path = get_path(args.base_dir, 'run-tms-reco', args.tmsreco_name,
+                                    'TMSRECO', 'root', args.file_id)
+            outf.write(f'nd_cafmaker.CAFMakerSettings.TMSRecoFile: "{tmsreco_path}"\n')
 
 if __name__ == '__main__':
     main()

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -43,7 +43,7 @@ def main():
     ap.add_argument('--spine-name', required=True)
     ap.add_argument('--tmsreco-name', required=False)
     ap.add_argument('--minerva-name', required=False)
-    ap.add_argument('--edepsim-name', required=True)
+    ap.add_argument('--edepsim-name', required=False)
     ap.add_argument('--caf-path', required=True)
     ap.add_argument('--cfg-file', required=True)
     ap.add_argument('--file-id', required=True, type=int)
@@ -86,13 +86,15 @@ def main():
                                     'TMSRECO', 'root', args.file_id)
             outf.write(f'nd_cafmaker.CAFMakerSettings.TMSRecoFile: "{tmsreco_path}"\n')
 
-        edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
-                                'EDEPSIM_SPILLS','root',args.file_id) 
-        outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
+        if args.edepsim_name:
+            edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
+                                    'EDEPSIM_SPILLS','root',args.file_id) 
+            outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
 
         if args.extra_lines:
             for extra_line in args.extra_lines.split(";"): 
                 outf.write(f'{extra_line}')
+                outf.write("\n")
 
 if __name__ == '__main__':
     main()

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -16,7 +16,9 @@ def get_path(base_dir, step, name, ftype, ext, file_id: int):
     subdir = file_id // 1000 * 1000
     subdir = f'{subdir:07d}'
     # Temporary special case for Minerva
-    ftype2 = 'dst' if ftype == 'DST' else ftype
+    ftype2 = ftype
+    ftype2 = 'dst' if ftype == 'DST' else ftype2 
+    ftype2 = 'SPINE' if ftype == 'MLRECO_ANALYSIS' else ftype2 
     path = (f'{base_dir}/{step}/{name}/{ftype}/{subdir}' +
             f'/{name}.{file_id:07d}.{ftype2}.{ext}')
     if not os.path.exists(path):
@@ -38,9 +40,10 @@ def main():
     ap.add_argument('--base-dir', required=True)
     ap.add_argument('--ghep-nu-name', required=False)
     ap.add_argument('--ghep-rock-name', required=False)
-    ap.add_argument('--mlreco-name', required=True)
+    ap.add_argument('--spine-name', required=True)
     ap.add_argument('--tmsreco-name', required=False)
     ap.add_argument('--minerva-name', required=False)
+    ap.add_argument('--edepsim-name', required=False)
     ap.add_argument('--caf-path', required=True)
     ap.add_argument('--cfg-file', required=True)
     ap.add_argument('--file-id', required=True, type=int)
@@ -68,9 +71,9 @@ def main():
         caf_path = args.caf_path
         outf.write(f'nd_cafmaker.CAFMakerSettings.OutputFile: "{caf_path}"\n')
 
-        mlreco_path = get_path(args.base_dir, 'run-mlreco', args.mlreco_name,
-                               'MLRECO_ANA', 'hdf5', args.file_id)
-        outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{mlreco_path}"\n')
+        spine_path = get_path(args.base_dir, 'run-spine', args.spine_name,
+                               'MLRECO_ANALYSIS', 'hdf5', args.file_id)
+        outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{spine_path}"\n')
 
         if args.minerva_name:
             minerva_path = get_path(args.base_dir, 'run-minerva', args.minerva_name,
@@ -81,6 +84,10 @@ def main():
             tmsreco_path = get_path(args.base_dir, 'run-tms-reco', args.tmsreco_name,
                                     'TMSRECO', 'root', args.file_id)
             outf.write(f'nd_cafmaker.CAFMakerSettings.TMSRecoFile: "{tmsreco_path}"\n')
+
+        edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
+                                'EDEPSIM_SPILLS','root',args.file_id) 
+        outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
 
 if __name__ == '__main__':
     main()

--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -91,8 +91,8 @@ def main():
         outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
 
         if args.extra_lines:
-            for extra_line in args.extra_lines: 
-                outf.write(f'{extra_line}\n')
+            for extra_line in args.extra_lines.split(";"): 
+                outf.write(f'{extra_line}')
 
 if __name__ == '__main__':
     main()

--- a/run-cafmaker/install_cafmaker.sh
+++ b/run-cafmaker/install_cafmaker.sh
@@ -11,7 +11,7 @@ setup edepsim v3_2_0c -q e20:prof
 mkdir install
 cd install
 
-git clone v4.6.5 https://github.com/DUNE/ND_CAFMaker.git
+git clone -b v4.6.5 https://github.com/DUNE/ND_CAFMaker.git
 cd ND_CAFMaker
 
 ./build.sh

--- a/run-cafmaker/install_cafmaker.sh
+++ b/run-cafmaker/install_cafmaker.sh
@@ -11,7 +11,7 @@ setup edepsim v3_2_0c -q e20:prof
 mkdir install
 cd install
 
-git clone -b v4.6.3 https://github.com/DUNE/ND_CAFMaker.git
+git clone v4.6.5 https://github.com/DUNE/ND_CAFMaker.git
 cd ND_CAFMaker
 
 ./build.sh

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -17,7 +17,6 @@ cfgFile=$(mktemp --suffix .cfg)
 args_gen_cafmaker_cfg=( \
     --base-dir "$ARCUBE_OUTDIR_BASE" \
     --spine-name "$ARCUBE_SPINE_NAME" \
-    --minerva-name "$ARCUBE_MINERVA_NAME" \
     --edepsim-name "$ARCUBE_SPILL_NAME" \
     --caf-path "$outFile" \
     --cfg-file "$cfgFile" \
@@ -29,6 +28,7 @@ args_gen_cafmaker_cfg=( \
 [ -n "${ARCUBE_MINERVA_NAME}" ] && args_gen_cafmaker_cfg+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
 [ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gen_cafmaker_cfg+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
 [ -n "${ARCUBE_HADD_FACTOR}" ] && args_gen_cafmaker_cfg+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )
+[ -n "${ARCUBE_EXTRA_LINES}" ] && args_gen_cafmaker_cfg+=( --extra-lines "$ARCUBE_EXTRA_LINES" )
 
 ./gen_cafmaker_cfg.py "${args_gen_cafmaker_cfg[@]}"
 

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -34,6 +34,7 @@ args_gen_cafmaker_cfg=( \
 
 echo ===================
 cat "$cfgFile"
+echo ""
 echo ===================
 
 run makeCAF "--fcl=$cfgFile"

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -17,7 +17,6 @@ cfgFile=$(mktemp --suffix .cfg)
 args_gen_cafmaker_cfg=( \
     --base-dir "$ARCUBE_OUTDIR_BASE" \
     --spine-name "$ARCUBE_SPINE_NAME" \
-    --edepsim-name "$ARCUBE_SPILL_NAME" \
     --caf-path "$outFile" \
     --cfg-file "$cfgFile" \
     --file-id "$ARCUBE_INDEX" \
@@ -25,6 +24,7 @@ args_gen_cafmaker_cfg=( \
 
 [ -n "${ARCUBE_GHEP_NU_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" )
 [ -n "${ARCUBE_GHEP_ROCK_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" )
+[ -n "${ARCUBE_SPILL_NAME}" ] && args_gen_cafmaker_cfg+=( --edepsim-name "$ARCUBE_SPILL_NAME" )
 [ -n "${ARCUBE_MINERVA_NAME}" ] && args_gen_cafmaker_cfg+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
 [ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gen_cafmaker_cfg+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
 [ -n "${ARCUBE_HADD_FACTOR}" ] && args_gen_cafmaker_cfg+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -16,7 +16,9 @@ cfgFile=$(mktemp --suffix .cfg)
 # Compulsory arguments.
 args_gen_cafmaker_cfg=( \
     --base-dir "$ARCUBE_OUTDIR_BASE" \
-    --mlreco-name "$ARCUBE_MLRECO_NAME" \
+    --spine-name "$ARCUBE_SPINE_NAME" \
+    --minerva-name "$ARCUBE_MINERVA_NAME" \
+    --edepsim-name "$ARCUBE_SPILL_NAME" \
     --caf-path "$outFile" \
     --cfg-file "$cfgFile" \
     --file-id "$ARCUBE_INDEX" \

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -13,15 +13,22 @@ outFile=${tmpOutDir}/${outName}.CAF.root
 flatOutFile=${tmpOutDir}/${outName}.CAF.flat.root
 cfgFile=$(mktemp --suffix .cfg)
 
-./gen_cafmaker_cfg.py \
+# Compulsory arguments.
+args_gen_cafmaker_cfg=( \
     --base-dir "$ARCUBE_OUTDIR_BASE" \
-    --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" \
-    --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" \
     --mlreco-name "$ARCUBE_MLRECO_NAME" \
-    --minerva-name "$ARCUBE_MINERVA_NAME" \
     --caf-path "$outFile" \
     --cfg-file "$cfgFile" \
-    --file-id "$ARCUBE_INDEX"
+    --file-id "$ARCUBE_INDEX" \
+    )
+
+[ -n "${ARCUBE_GHEP_NU_NAME}" ] && args_gevgen_fnal+=( --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" )
+[ -n "${ARCUBE_GHEP_ROCK_NAME}" ] && args_gevgen_fnal+=( --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" )
+[ -n "${ARCUBE_MINERVA_NAME}" ] && args_gevgen_fnal+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
+[ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gevgen_fnal+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
+[ -n "${ARCUBE_HADD_FACTOR}" ] && args_gevgen_fnal+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )
+
+./gen_cafmaker_cfg.py "${args_gen_cafmaker_cfg[@]}"
 
 echo ===================
 cat "$cfgFile"

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -22,11 +22,11 @@ args_gen_cafmaker_cfg=( \
     --file-id "$ARCUBE_INDEX" \
     )
 
-[ -n "${ARCUBE_GHEP_NU_NAME}" ] && args_gevgen_fnal+=( --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" )
-[ -n "${ARCUBE_GHEP_ROCK_NAME}" ] && args_gevgen_fnal+=( --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" )
-[ -n "${ARCUBE_MINERVA_NAME}" ] && args_gevgen_fnal+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
-[ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gevgen_fnal+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
-[ -n "${ARCUBE_HADD_FACTOR}" ] && args_gevgen_fnal+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )
+[ -n "${ARCUBE_GHEP_NU_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" )
+[ -n "${ARCUBE_GHEP_ROCK_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" )
+[ -n "${ARCUBE_MINERVA_NAME}" ] && args_gen_cafmaker_cfg+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
+[ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gen_cafmaker_cfg+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
+[ -n "${ARCUBE_HADD_FACTOR}" ] && args_gen_cafmaker_cfg+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )
 
 ./gen_cafmaker_cfg.py "${args_gen_cafmaker_cfg[@]}"
 


### PR DESCRIPTION
A few additions here, mainly to `run_cafmaker` and the `fhicl` config generator - requesting a careful review please :) to summarise:

- Make several arguments of generator none compulsory, e.g you don't need to specify rock now. Changes have also been reflected in `run_cafmaker`.
- `mlreco` / `MLRECO_ANALYSIS` -> `spine` / `MLRECO_SPINE`.
- Add TMS reco input.
- Add EDepSim spill level input (work done by Noe).
- Remove hardcoding of hadd factor, replace it with an argument with a default value instead.
- Add an argument to be able to specify a semi-colon separated list of arbitrary extra lines. In the example config dumped below, added a line to only run over 1 event using this tool.
- Bump the CAFMaker tag to the MiniRun6 one.

```
#include "NDCAFMaker.fcl"

nd_cafmaker: @local::standard_nd_cafmaker

nd_cafmaker.CAFMakerSettings.GHEPFiles: [
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001150.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001151.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001152.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001153.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001154.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001155.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001156.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001157.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001158.GHEP.root",
   "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-genie/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu/GHEP/0001000/MicroProdN1p1_NDLAr_1E18_RHC.genie.nu.0001159.GHEP.root"

]

nd_cafmaker.CAFMakerSettings.OutputFile: "/pscratch/sd/a/abooth/MicroProdN1p1/output/tmp/run-cafmaker/MicroProdN1p1_NDLAr_1E18_RHC.caf.nu/MicroProdN1p1_NDLAr_1E18_RHC.caf.nu.0000115.CAF.root"
nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-mlreco/MicroProdN1p1_NDLAr_1E18_RHC.mlreco_spine.nu.morecorrectcontainment/MLRECO_SPINE/0000000/MicroProdN1p1_NDLAr_1E18_RHC.mlreco_spine.nu.morecorrectcontainment.0000115.MLRECO_SPINE.hdf5"
nd_cafmaker.CAFMakerSettings.EdepsimFile: "/pscratch/sd/a/abooth/MicroProdN1p1/output/run-spill-build/MicroProdN1p1_NDLAr_1E18_RHC.spill.nu/EDEPSIM_SPILLS/0000000/MicroProdN1p1_NDLAr_1E18_RHC.spill.nu.0000115.EDEPSIM_SPILLS.root"
nd_cafmaker.CAFMakerSettings.NumEvts: 1
```