### PR TITLE
Minor `run_spine.sh` tweak plus `run-validation` additions

### DIFF
--- a/run-mlreco/run_spine.sh
+++ b/run-mlreco/run_spine.sh
@@ -24,6 +24,7 @@ sed "s!%TMPDIR%!${tmpDir}!g" "configs/${config}" > "${tmpDir}/${config}"
 
 run python3 install/spine/bin/run.py \
     --config "${tmpDir}/${config}" \
+    --log_dir "$logDir" \
     --source "$inFile" \
     --output "$outFile"
 

--- a/run-validation/analyse_footprint.py
+++ b/run-validation/analyse_footprint.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import argparse
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+
+from matplotlib.backends.backend_pdf import PdfPages
+
+
+def convert_to_gb_float(kb_string):
+        
+    return float(kb_string)/1.0e6
+
+
+def main(in_file, out_dir):
+    production_steps = []
+    with open (in_file) as f:
+        production_steps = np.array([ production_step.rstrip("\n").split("\t") for production_step in f ])
+   
+    production_step_sizes = production_steps[:,0]
+    production_step_names = production_steps[:,1]
+
+    production_step_sizes = np.array([ convert_to_gb_float(production_step_size) for production_step_size in production_step_sizes ])
+    size_order = np.argsort(production_step_sizes)
+
+
+    with PdfPages(out_dir+"/analyse_footprint.pdf") as output:
+        fig, ax = plt.subplots()
+        plt.gcf().subplots_adjust(left=0.2)
+        y_pos = np.arange(len(production_steps))
+        ax.barh(y_pos, production_step_sizes[size_order], align='center')
+        ax.set_yticks(y_pos, labels=production_step_names[size_order])
+        ax.set_title("Total Footprint: "+str(int(sum(production_step_sizes)))+" GB")
+        ax.set_xlabel("Output File Footprint (GB)")
+        output.savefig()
+        plt.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--in_file', default=None, required=True, type=str, help='''string corresponding to file with output of du -hk command.''')
+    parser.add_argument('--out_dir', default="./", required=True, type=str, help='''string corresponding to the directory path to write output pdf.''')
+    args = parser.parse_args()
+    main(**vars(args))

--- a/run-validation/edepsim_validation.py
+++ b/run-validation/edepsim_validation.py
@@ -460,15 +460,25 @@ def main(sim_file, input_type, det_complex):
         spill = 0
         packet_duration = 10
         epsillon = 5
-        while ((spill+1)*spill_duration < max_time):
+        n_vertices_per_spill = []
+        while (spill < len(event_id_uniq)):
             this_vertices_time = vertices_time[vertices_time > spill*spill_duration - epsillon]
             this_vertices_time = this_vertices_time[this_vertices_time < spill*(spill_duration) + packet_duration + epsillon]
+            n_vertices_per_spill.append(len(this_vertices_time))
             plt.hist(this_vertices_time, bins=100, range=[spill*spill_duration - epsillon, spill*spill_duration+packet_duration + epsillon])
             plt.xlabel('Vertex t_vert (us)')
             plt.ylabel(r'N Vertices')
             output.savefig()
             plt.close()
             spill += 1
+
+        ### Plot the number of vertices per spill.    
+        plt.hist(n_vertices_per_spill, bins=20)
+        plt.title("Total Vertices: "+str(sum(n_vertices_per_spill)))
+        plt.xlabel('Number of Vertices per Spill')
+        plt.ylabel(r'Spills')
+        output.savefig()
+        plt.close()
 
 
 if __name__ == '__main__':

--- a/run-validation/run_analyse_footprint_interactive.sh
+++ b/run-validation/run_analyse_footprint_interactive.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+module load python
+
+source validation.venv/bin/activate
+
+
+BASEDIR=/pscratch/sd/a/abooth/MicroProdN3p1/output
+OUTDIR=/pscratch/sd/a/abooth/MicroProdN3p1/output/run-validation/PLOTS/analyses_footprint
+mkdir -p $OUTDIR
+
+
+# Make a basic file with size of each subdirectory
+# in BASEDIR.
+inFile=$(mktemp --suffix .in)
+cd $BASEDIR
+for dir in `ls`
+do
+  if [[ $dir == *"run-validation"* ]]; then continue
+  elif [[ $dir == *"tmp"* ]]; then continue
+  fi
+  du -hk ${dir} | tail -n 1 >> $inFile
+done
+cd -
+
+
+python analyse_footprint.py --in_file $inFile --out_dir $OUTDIR
+
+
+# Remove the temporary file.
+rm $inFile


### PR DESCRIPTION
One minor change to `run_spine.sh` to force use of `--log_dir`. If you're software lives in a directory that is read only for the grid nodes, writing in-place logs (the default) doesn't work.

Other changes are all validation related:
- Add a new plot to `edep` script for number of vertices per spill.
- Make timing analysis script use `os.walk` so can deal with subdirectories of `TIME` files.
- New script (and accompanying example bash script) to produce a horizontal bar chart showing file footprints for a production. 