### PR TITLE
Add optional use of `event-generator-list` via env var to `run_genie`

### DIFF
--- a/run-genie/run_genie.sh
+++ b/run-genie/run_genie.sh
@@ -53,6 +53,7 @@ args_gevgen_fnal=( \
 [ -n "${ARCUBE_TOP_VOLUME}" ] && args_gevgen_fnal+=( -t "$ARCUBE_TOP_VOLUME" )
 [ -n "${ARCUBE_FID_CUT_STRING}" ] && args_gevgen_fnal+=( -F "$ARCUBE_FID_CUT_STRING" )
 [ -n "${ARCUBE_ZMIN}" ] && args_gevgen_fnal+=( -z "$ARCUBE_ZMIN" )
+[ -n "${ARCUBE_EVENT_GEN_LIST}" ] && args_gevgen_fnal+=( --event-generator-list "$ARCUBE_EVENT_GEN_LIST" )
 
 run gevgen_fnal "${args_gevgen_fnal[@]}"
 


### PR DESCRIPTION
Cherry picked from commit cdeac6066f3a594acc434733e65eeeb1e19118c5 in the `production-MicroProdN1p1` branch. 

This minor addition allows the production of "special samples" such as one that only contains interactions of beam neutrinos with orbital electrons, achieved with `ARCUBE_EVENT_GEN_LIST: 'NuE'`.

The attached pdf shows example "spills" (where one interaction per spill has been specified) and other basic validation plots from a small sample `MicroProdN3p2` which has been completed up to (not including) `larnd-sim`.

[Uploading edephdf5_analysis_starter_MicroProdN3p2_forgit.pdf…]()

Given this is a minor change, I'll wait for 24 hours for any objections and then merge.