### PR TITLE
Quality of Life Improvements in `run-cafmaker`

### DIFF
--- a/run-cafmaker/gen_cafmaker_cfg.py
+++ b/run-cafmaker/gen_cafmaker_cfg.py
@@ -40,8 +40,8 @@ def main():
     ap.add_argument('--base-dir', required=True)
     ap.add_argument('--ghep-nu-name', required=False)
     ap.add_argument('--ghep-rock-name', required=False)
-    ap.add_argument('--spine-name', required=True)
-    ap.add_argument('--pandora-name', required=True)
+    ap.add_argument('--spine-name', required=False)
+    ap.add_argument('--pandora-name', required=False)
     ap.add_argument('--tmsreco-name', required=False)
     ap.add_argument('--minerva-name', required=False)
     ap.add_argument('--edepsim-name', required=False)
@@ -54,6 +54,9 @@ def main():
 
     if not args.ghep_nu_name and not args.ghep_rock_name:
         raise ValueError("One or both of ghep-nu-name and ghep-rock-name must be specified")
+
+    if not args.spine_name and not args.pandora_name:
+        raise ValueError("One or both of spine-name and pandora-name must be specified")
 
     with open(args.cfg_file, 'w') as outf:
         outf.write(PREAMBLE)
@@ -73,13 +76,15 @@ def main():
         caf_path = args.caf_path
         outf.write(f'nd_cafmaker.CAFMakerSettings.OutputFile: "{caf_path}"\n')
 
-        spine_path = get_path(args.base_dir, 'run-mlreco', args.spine_name,
-                               'MLRECO_SPINE', 'hdf5', args.file_id)
-        outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{spine_path}"\n')
+        if args.spine_name:
+            spine_path = get_path(args.base_dir, 'run-mlreco', args.spine_name,
+                                  'MLRECO_SPINE', 'hdf5', args.file_id)
+            outf.write(f'nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "{spine_path}"\n')
 
-        pandora_path = get_path(args.base_dir, 'run-pandora', args.pandora_name,
-                                'LAR_RECO_ND', 'root', args.file_id)
-        outf.write(f'nd_cafmaker.CAFMakerSettings.PandoraLArRecoNDFile: "{pandora_path}"\n')
+        if args.pandora_name:
+            pandora_path = get_path(args.base_dir, 'run-pandora', args.pandora_name,
+                                    'LAR_RECO_ND', 'root', args.file_id)
+            outf.write(f'nd_cafmaker.CAFMakerSettings.PandoraLArRecoNDFile: "{pandora_path}"\n')
 
         if args.minerva_name:
             minerva_path = get_path(args.base_dir, 'run-minerva', args.minerva_name,
@@ -91,10 +96,9 @@ def main():
                                     'TMSRECO', 'root', args.file_id)
             outf.write(f'nd_cafmaker.CAFMakerSettings.TMSRecoFile: "{tmsreco_path}"\n')
 
-        if args.edepsim_name:
-            edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
-                                    'EDEPSIM_SPILLS','root',args.file_id) 
-            outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
+        edepsim_path = get_path(args.base_dir, 'run-spill-build', args.edepsim_name,
+                                'EDEPSIM_SPILLS','root',args.file_id) 
+        outf.write(f'nd_cafmaker.CAFMakerSettings.EdepsimFile: "{edepsim_path}"\n')
 
         if args.extra_lines:
             for extra_line in args.extra_lines.split(";"): 

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -13,11 +13,10 @@ outFile=${tmpOutDir}/${outName}.CAF.root
 flatOutFile=${tmpOutDir}/${outName}.CAF.flat.root
 cfgFile=$(mktemp --suffix .cfg)
 
-# Compulsory arguments.
+# Compulsory arguments regardless of use case.
 args_gen_cafmaker_cfg=( \
     --base-dir "$ARCUBE_OUTDIR_BASE" \
-    --spine-name "$ARCUBE_SPINE_NAME" \
-    --pandora-name "$ARCUBE_PANDORA_NAME" \
+    --edepsim-name "$ARCUBE_SPILL_NAME" \
     --caf-path "$outFile" \
     --cfg-file "$cfgFile" \
     --file-id "$ARCUBE_INDEX" \
@@ -25,8 +24,9 @@ args_gen_cafmaker_cfg=( \
 
 [ -n "${ARCUBE_GHEP_NU_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-nu-name "$ARCUBE_GHEP_NU_NAME" )
 [ -n "${ARCUBE_GHEP_ROCK_NAME}" ] && args_gen_cafmaker_cfg+=( --ghep-rock-name "$ARCUBE_GHEP_ROCK_NAME" )
-[ -n "${ARCUBE_SPILL_NAME}" ] && args_gen_cafmaker_cfg+=( --edepsim-name "$ARCUBE_SPILL_NAME" )
 [ -n "${ARCUBE_MINERVA_NAME}" ] && args_gen_cafmaker_cfg+=( --minerva-name "$ARCUBE_MINERVA_NAME" )
+[ -n "${ARCUBE_SPINE_NAME}" ] && args_gen_cafmaker_cfg+=( --spine-name "$ARCUBE_SPINE_NAME" )
+[ -n "${ARCUBE_PANDORA_NAME}" ] && args_gen_cafmaker_cfg+=( --pandora-name "$ARCUBE_PANDORA_NAME" )
 [ -n "${ARCUBE_TMSRECO_NAME}" ] && args_gen_cafmaker_cfg+=( --tmsreco-name "$ARCUBE_TMSRECO_NAME" )
 [ -n "${ARCUBE_HADD_FACTOR}" ] && args_gen_cafmaker_cfg+=( --hadd-factor "$ARCUBE_HADD_FACTOR" )
 [ -n "${ARCUBE_EXTRA_LINES}" ] && args_gen_cafmaker_cfg+=( --extra-lines "$ARCUBE_EXTRA_LINES" )


### PR DESCRIPTION
A change in compulsory and non-compulsory arguments for `gen_cafmaker_cfg.py` to better reflect current workflow:

- Make `edepsim-name` a compulsory argument.
- Change requirement for including both `spine-name` and `pandora-name` to just one or both.