### PR TITLE
Feature/mdolce metadata

### DIFF
--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -251,9 +251,10 @@ def main():
     if args.one:
         dump_metadata(args.one, args)
     else:
-        ext = file_format(args.all)
-        paths = args.all.glob(f'*.{ext}')
+        a_file_ext = next((file.suffix[1:] for file in args.all.iterdir() if file.is_file()), None)
+        paths = args.all.glob(f'*.{a_file_ext}')
         pool = Pool(args.nproc)
+        print('Here are the args received: ', args)
         pool.starmap(dump_metadata,
                     [(p, args) for p in paths])
 

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -90,7 +90,7 @@ def file_format(datapath: Path):
         return 'hdf5'
     return datapath.suffix[1:]
 
-
+# TODO: we should ask Computing to make these namespaces for us soon
 def get_runtype(args: argparse.Namespace):
     if args.app == 'run-spill-build':
         return 'neardet-2x2'
@@ -152,7 +152,7 @@ def dump_metadata(datapath: Path, args: argparse.Namespace):
     meta = {}
 
     meta['file_name'] = datapath.name
-    meta['namespace'] = 'ndprod'
+    meta['namespace'] = args.namespace
     meta['file_size'] = datapath.stat().st_size
 
     if args.sam:                # for samweb validate-metadata
@@ -179,7 +179,7 @@ def dump_metadata(datapath: Path, args: argparse.Namespace):
         'core.file_type': 'mc' if args.mc else 'detector',
         'core.file_format': file_format(datapath),
         'core.group': 'dune',
-        'core.run_type': get_runtype(args),
+        'core.run_type': args.namespace,            # NOTE: must match namespace
         'core.runs': [get_runno(datapath)],
         'core.file_content_status': 'good',
 
@@ -226,6 +226,7 @@ def main():
     inputs.add_argument('--one', type=Path, help='One file to process')
     inputs.add_argument('--all', type=Path, help='Whole directory to process')
     ap.add_argument('--campaign', help='Name of campaign', required=True)
+    ap.add_argument('--namespace', help='metacat namespace to declare dataset to', choices=['neardet-lar-tms'])
     ap.add_argument('--mc', action='store_true',)
     ap.add_argument('--genie-tune', default='AR23_20i_00_000', help='Name of genie tune (CMC)')
     ap.add_argument('--nu', action='store_true', help='true for nu, false for rock')

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -16,8 +16,12 @@ import h5py
 import numpy as np
 import ROOT as R
 
-g4evtdir = os.getenv('LIBTG4EVENT_DIR', 'libTG4Event')
-R.gSystem.Load(f'{g4evtdir}/libTG4Event.so')
+# For AL9 running, source dune-tms/setup_FNAL.sh script first.
+
+# Currently, have an issue with GEANT. Omitting works for now.
+# though we should silence the warnings.....?
+#g4evtdir = os.getenv('LIBTG4EVENT_DIR', 'libTG4Event')
+#R.gSystem.Load(f'{g4evtdir}/libTG4Event.so')
 
 
 def get_event_stats_edep(datapath: Path):
@@ -103,7 +107,7 @@ def get_data_tier(args: argparse.Namespace):
         return 'detector-simulated'
     elif args.app == 'run-ndlar-flow':
         return 'hit-reconstructed'
-    elif args.app == 'run-tms-reco':  # TODO: This is to be decided.
+    elif args.app == 'run-tms-reco':
         return 'root-tuple'
 
 

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -6,6 +6,7 @@
 
 import argparse
 import json
+import subprocess
 from multiprocessing import Pool
 import os
 from pathlib import Path
@@ -47,6 +48,13 @@ def get_event_stats_hdf5(datapath: Path, dset_name: str, event_id_var: str):
 
         return int(count), int(first), int(last)
 
+def get_event_stats_tms(datapath: Path):
+    f = R.TFile(datapath.as_posix())
+    t = f.Line_Candidates
+    count = t.GetEntries()
+    first = t.GetEntry(0)
+    last = t.GetEntries() - 1
+    return int(count), int(first), int(last)
 
 # NOTE: According to
 # https://github.com/DUNE/data-mgmt-testing/blob/main/metacat/rawDataExample.md
@@ -59,7 +67,19 @@ def get_checksum(datapath: Path, chunksize=1_000_000_000):
             cksum = zlib.adler32(data, cksum)
     return cksum & 0xffffffff
 
-
+# TODO: the repos are all on NERSC, so would need to get the branch names yourself (if using GPVMS),
+#  or run this script on NERSC directly
+def get_current_git_branch(repopath: str) -> str:
+    try:
+        result = subprocess.run(
+            ['git', '-C', repopath, 'branch'],
+            capture_output=True, text=True, check=True
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith('*'): # this is the branch checked out
+                return line.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: {e}")
 
 def file_format(datapath: Path):
     if datapath.suffix == '.h5':
@@ -95,6 +115,8 @@ def get_event_stats(datapath: Path, args: argparse.Namespace):
     elif args.app == 'run-ndlar-flow':
         return get_event_stats_hdf5(datapath, '/mc_truth/trajectories/data',
                                     args.event_id_var)
+    elif args.app == 'run-tms-reco':
+        return get_event_stats_tms(datapath)
 
 
 def get_parents(datapath: Path, args: argparse.Namespace):
@@ -117,43 +139,74 @@ def get_parents(datapath: Path, args: argparse.Namespace):
 def get_runno(datapath: Path):
     return int(datapath.name.split('.')[-3])
 
+def get_data_stream(f, args: argparse.Namespace):
+    if ds := args.data_stream:
+        return ds
+    return 'physics'
 
 def dump_metadata(datapath: Path, args: argparse.Namespace):
     meta = {}
 
     meta['file_name'] = datapath.name
-    meta['file_type'] = 'mc'
+    meta['namespace'] = 'neardet-lar-tms'
     meta['file_size'] = datapath.stat().st_size
-    meta['file_format'] = get_ext(args)
 
     if args.sam:                # for samweb validate-metadata
         meta['checksum'] = [f'adler32:{get_checksum(datapath):08x}']
     else:                       # for declaration daemon
         meta['checksum'] = f'{get_checksum(datapath):08x}'
 
-    meta['data_stream'] = 'physics'
-    meta['group'] = 'dune'
-    meta['application'] = {'family': args.family,
-                           'name': args.app,
-                           'version': args.campaign}
-
-    meta['DUNE.campaign'] = args.campaign
-    meta['DUNE.generators'] = 'genie'
-    meta['DUNE_MC.geometry_version'] = args.geom
-    meta['DUNE_MC.name'] = args.campaign
-    meta['DUNE_MC.TopVolume'] = args.top_vol
-    meta['LBNF_MC.HornCurrent'] = args.horn_current
-    # TODO: Do we want the genie tune? Does the field 
-    # exist already?
-
-    meta['data_tier'] = get_data_tier(args)
-    meta['runs'] = [[get_runno(datapath), 1, get_runtype(args)]]
-
-    meta['event_count'], meta['first_event'], meta['last_event'] = \
-        get_event_stats(datapath, args)
-
     if parents := get_parents(datapath, args):
         meta['parents'] = parents
+
+    meta['dune.campaign'] = args.campaign   # e.g. "MiniProdN1p1_NDLAr_1E19_RHC"
+
+    # meta['dune.horn_current'] = args.horn_current  # TODO: add the horn current
+
+    md = meta['metadata'] = {
+        'core.application.family': args.family,
+        'core.application.name': args.app,
+        'core.application.version' : 'xx',          # TODO: what DUNESW version?
+        'core.data_stream': get_data_stream(datapath, args),
+        'core.data_tier': get_data_tier(args),
+        'core.event_count': get_event_stats(datapath, args)[0],
+        'core.first_event': get_event_stats(datapath, args)[1],
+        'core.last_event': get_event_stats(datapath, args)[2],
+        'core.file_type': 'mc' if args.mc else 'detector',
+        'core.file_format': file_format(datapath),
+        'core.group': 'dune',
+        'core.run_type': get_runtype(args),
+        'core.runs': [get_runno(datapath)],
+        'core.file_content_status': 'good',
+
+        'retention.class': 'physics',
+        'retention.status': 'active',
+    }
+    if args.mc:
+        mc_metadata = {
+            'dune_mc.name' : args.campaign,
+            'dune_mc.generators' :  'genie',
+            'dune_mc.genie_tune' : args.genie_tune,
+            'dune_mc.top_volume' : args.top_vol,
+            'dune_mc.geometry_version' : args.geom,
+
+            # NOTE: default to Jan 2025 latest versions...
+            'dune_mc.2x2_sim.tag': get_current_git_branch(args.repo_2x2sim) if args.repo_2x2sim  else 'nd-production-v02.01',   # TODO: should we have a default?
+            'dune_mc.fireworks4dune.tag': get_current_git_branch(args.repo_fw) if args.repo_fw else 'main',
+            'dune_mc.ND_Production.tag': get_current_git_branch(args.repo_ndprod) if args.repo_ndprod else 'nd-production-v02.01',
+
+            'dune_mc.nu': args.nu,
+            'dune_mc.rock': not args.nu,
+
+            'cluster.gen_site': 'nersc',
+            'cluster.hostname' : 'xx',                       # todo: do we want these at all.....?
+            'cluster.os' : 'xx',
+            'cluster.os_version' : 'xx',
+            'cluster.compiler' : 'xx',
+
+        }
+        meta['metadata'].update(mc_metadata)
+
 
     jsonpath = datapath.with_suffix(datapath.suffix + '.json')
     print(f'Dumping to {jsonpath}')
@@ -167,34 +220,36 @@ def main():
     inputs = ap.add_mutually_exclusive_group(required=True)
     inputs.add_argument('--one', type=Path, help='One file to process')
     inputs.add_argument('--all', type=Path, help='Whole directory to process')
+    ap.add_argument('--campaign', help='Name of campaign', required=True)
+    ap.add_argument('--mc', action='store_true',)
+    ap.add_argument('--genie-tune', help='Name of genie tune (CMC)', required=True)
+    ap.add_argument('--nu', action='store_true', help='true for nu, false for rock')
+    ap.add_argument('--parents', help='record parent info')
     ap.add_argument('--app', help='Name of application', required=True,
                     choices=['run-spill-build',
                              'run-larnd-sim',
                              'run-ndlar-flow',
-                             'run-tms-reco'])
+                             'run-tms-reco']) # TODO: will need to add the further processes
     ap.add_argument('--family', help='Name of family', required=True, 
-                    # TODO: Are we happy with ND_Production
-                    # as the family?
-                    choices=['2x2_sim',
-                             'ND_Production'], default='2x2_sim')
-    ap.add_argument('--campaign', help='Name of campaign', required=True)
+                    choices=['2x2_sim', 'ND_Production'], default='ND_Production') # TODO: Are we happy with ND_Production as the family?
     ap.add_argument('--geom', help='Name of geometry', required=True)
     ap.add_argument('--top-vol', help='Name of top volume', required=True)
-    ap.add_argument('--horn-current', help='Horn current in kA', type=float,
-                    required=True)
+    ap.add_argument('--repo-2x2sim', help='Path to 2x2sim repo')
+    ap.add_argument('--repo-fw', help='Path to Fireworks4Dune repo')
+    ap.add_argument('--repo-ndprod', help='Path to ND_Production repo')
+    # ap.add_argument('--horn-current', help='Horn current in kA', type=float, required=True)
     # eventID was used for MiniRun3:
     ap.add_argument('--event-id-var', help='Name of event ID variable',
                     choices=['event_id', 'eventID'], default='event_id')
     ap.add_argument('--nproc', help='Number of parallel processes', type=int, default=8)
     ap.add_argument('--sam', help='SAM compatibility mode (only affects checksum syntax)',
                     action='store_true')
-    ap.add_argument('--parents')
     args = ap.parse_args()
 
     if args.one:
         dump_metadata(args.one, args)
     else:
-        ext = get_ext(args)
+        ext = file_format(args.all)
         paths = args.all.glob(f'*.{ext}')
         pool = Pool(args.nproc)
         pool.starmap(dump_metadata,

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -222,7 +222,7 @@ def main():
     inputs.add_argument('--all', type=Path, help='Whole directory to process')
     ap.add_argument('--campaign', help='Name of campaign', required=True)
     ap.add_argument('--mc', action='store_true',)
-    ap.add_argument('--genie-tune', default='AR23_20i_00_000', help='Name of genie tune (CMC)', required=True)
+    ap.add_argument('--genie-tune', default='AR23_20i_00_000', help='Name of genie tune (CMC)')
     ap.add_argument('--nu', action='store_true', help='true for nu, false for rock')
     ap.add_argument('--parents', help='record parent info')
     ap.add_argument('--app', help='Name of application', required=True,
@@ -232,6 +232,7 @@ def main():
                              'run-tms-reco']) # TODO: will need to add the further processes
     ap.add_argument('--family', help='Name of family', required=True, 
                     choices=['2x2_sim', 'ND_Production'], default='ND_Production') # TODO: Are we happy with ND_Production as the family?
+    ap.add_argument('--data-stream ', help='type of data taking (commissioning, calibration, test, physics, cosmics)', default='physics')
     ap.add_argument('--geom', help='Name of geometry', required=True)
     ap.add_argument('--top-vol', help='Name of top volume', required=True)
     ap.add_argument('--repo-2x2sim', help='Path to 2x2sim repo')

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -128,7 +128,7 @@ def get_parents(datapath: Path, args: argparse.Namespace):
         return None
     elif args.app in ['run-larnd-sim', 'run-tms-reco']:
         if not (base := args.parents):
-            base = f'{basename}.spill'
+            base = f'{basename}.spill'  # todo: may need to be fixed.
         return [f'{base}.{fileno}.EDEPSIM_SPILLS.root']
     elif args.app == 'run-ndlar-flow':
         if not (base := args.parents):
@@ -148,7 +148,7 @@ def dump_metadata(datapath: Path, args: argparse.Namespace):
     meta = {}
 
     meta['file_name'] = datapath.name
-    meta['namespace'] = 'neardet-lar-tms'
+    meta['namespace'] = 'ndprod'
     meta['file_size'] = datapath.stat().st_size
 
     if args.sam:                # for samweb validate-metadata
@@ -224,15 +224,15 @@ def main():
     ap.add_argument('--mc', action='store_true',)
     ap.add_argument('--genie-tune', default='AR23_20i_00_000', help='Name of genie tune (CMC)')
     ap.add_argument('--nu', action='store_true', help='true for nu, false for rock')
-    ap.add_argument('--parents', help='record parent info')
+#    ap.add_argument('--parents', help='record parent info')        # TODO: to get the parent info is not easy, so let's skip for now...
     ap.add_argument('--app', help='Name of application', required=True,
                     choices=['run-spill-build',
                              'run-larnd-sim',
                              'run-ndlar-flow',
                              'run-tms-reco']) # TODO: will need to add the further processes
-    ap.add_argument('--family', help='Name of family', required=True, 
+    ap.add_argument('--family', help='Name of family',
                     choices=['2x2_sim', 'ND_Production'], default='ND_Production') # TODO: Are we happy with ND_Production as the family?
-    ap.add_argument('--data-stream ', help='type of data taking (commissioning, calibration, test, physics, cosmics)', default='physics')
+    ap.add_argument('--data-stream', help='type of data taking (commissioning, calibration, test, physics, cosmics)', default='physics')
     ap.add_argument('--geom', help='Name of geometry', required=True)
     ap.add_argument('--top-vol', help='Name of top volume', required=True)
     ap.add_argument('--repo-2x2sim', help='Path to 2x2sim repo')

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -198,11 +198,12 @@ def dump_metadata(datapath: Path, args: argparse.Namespace):
             'dune_mc.nu': args.nu,
             'dune_mc.rock': not args.nu,
 
-            'cluster.gen_site': 'nersc',
-            'cluster.hostname' : 'xx',                       # todo: do we want these at all.....?
-            'cluster.os' : 'xx',
-            'cluster.os_version' : 'xx',
-            'cluster.compiler' : 'xx',
+            # todo: we will need to return to this, once we can run this script WITHIN the nersc job...
+            # 'cluster.gen_site': 'nersc',
+            # 'cluster.hostname' : 'xx',
+            # 'cluster.os' : 'xx',
+            # 'cluster.os_version' : 'xx',
+            # 'cluster.compiler' : 'xx',
 
         }
         meta['metadata'].update(mc_metadata)

--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -222,7 +222,7 @@ def main():
     inputs.add_argument('--all', type=Path, help='Whole directory to process')
     ap.add_argument('--campaign', help='Name of campaign', required=True)
     ap.add_argument('--mc', action='store_true',)
-    ap.add_argument('--genie-tune', help='Name of genie tune (CMC)', required=True)
+    ap.add_argument('--genie-tune', default='AR23_20i_00_000', help='Name of genie tune (CMC)', required=True)
     ap.add_argument('--nu', action='store_true', help='true for nu, false for rock')
     ap.add_argument('--parents', help='record parent info')
     ap.add_argument('--app', help='Name of application', required=True,


### PR DESCRIPTION
This is a working state of the  `dump_metadata.sh` script. Metadata was created, using this script, on the DUNE GPVMs, on `run-spill-build` output files for the TMS group to run reconstruction on for their geometry studies. 

To run this script: 
1. copy the files to DUNE GPVMs.
2. `cd <dune-tms/repo/dir> ; source setup_FNAL.sh`
3. `python /path/to/repo/2x2_sim/admin/dump_metadata.sh <metadata args>`

It is advised to do this in a `screen` session currently, as this can take a while. Also a drain is likely needed, especially if you have large files. 

Currently in draft state -- I handed the json and ROOT files of the spill build to Steve Timm for him to declare the files to `metacat` and `rucio`. I am waiting to hear back from Steve Timm on the status, just to be 100% sure it all succeeded. Once it does, I will make PR