### PR TITLE
Update `ndlar_flow` Workflow `yamls` in NDLAr Run Script to Latest Naming

### DIFF
--- a/run-ndlar-flow/run_ndlar_flow_ndlar.sh
+++ b/run-ndlar-flow/run_ndlar_flow_ndlar.sh
@@ -30,11 +30,11 @@ if [[ "$ARCUBE_COMPRESS" != "" ]]; then
 fi
 
 # charge workflows
-workflow1='yamls/ndlar_flow/workflows/charge/charge_event_building.yaml'
-workflow2='yamls/ndlar_flow/workflows/charge/charge_event_reconstruction.yaml'
-workflow3='yamls/ndlar_flow/workflows/combined/combined_reconstruction.yaml'
-workflow4='yamls/ndlar_flow/workflows/charge/prompt_calibration.yaml'
-workflow5='yamls/ndlar_flow/workflows/charge/final_calibration.yaml'
+workflow1='yamls/ndlar_flow/workflows/charge/charge_event_building_mc.yaml'
+workflow2='yamls/ndlar_flow/workflows/charge/charge_event_reconstruction_mc.yaml'
+workflow3='yamls/ndlar_flow/workflows/combined/combined_reconstruction_mc.yaml'
+workflow4='yamls/ndlar_flow/workflows/charge/prompt_calibration_mc.yaml'
+workflow5='yamls/ndlar_flow/workflows/charge/final_calibration_mc.yaml'
 
 cd "$ARCUBE_INSTALL_DIR"/ndlar_flow
 


### PR DESCRIPTION
This naming brings NDLAr back in line with 2x2.